### PR TITLE
Generalise invoice extraction and warn when OCR quality is poor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,24 @@
 ![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)
 ![Node 18+](https://img.shields.io/badge/node-18%2B-green)
 
-Upload monthly utility bills (images or PDFs), get them parsed and translated from Estonian to English automatically, and explore spending patterns through a 12-section analytics dashboard.
+Upload any invoice or bill (image or PDF), get it parsed into structured line items, and explore spending patterns through a 12-section analytics dashboard.
 
-Runs **entirely locally** — no API key required.
+Two extraction backends are available:
+- **Local OCR** *(default)* — Tesseract + `pdfplumber`, optimized for Estonian utility bills. Runs entirely locally, no API key required.
+- **Claude API** *(optional)* — handles any invoice type, any language, any layout. Set `PARSER_BACKEND=claude`.
 
 ## Features
 
-- **Open-source extraction**: Tesseract OCR for images, `pdfplumber` for native-text PDFs, `pdf2image` + OCR fallback for scanned PDFs
-- **Hardcoded Estonian→English dictionary** (~180 terms) — no API call needed for translation
+- **Two extraction backends** — local OCR for Estonian utility bills, Claude API for anything else (rent, subscriptions, services, non-Estonian invoices, scanned docs with unusual layouts)
+- **Automatic quality detection** — if the local OCR can't read the invoice, the UI shows a warning banner directing the user to switch to the Claude backend
+- **Open-source OCR pipeline**: Tesseract for images, `pdfplumber` for native-text PDFs, `pdf2image` + OCR fallback for scanned PDFs
+- **Hardcoded Estonian→English dictionary** (~180 terms) — no API call needed for translation when using the local backend
   - Utility services: electricity, gas, water, heating, telecom, waste
   - Korteriühistu line items: Haldusteenus, Küte, Remondifond, Tehnosüsteemide hooldusteenus…
   - Months (Jaanuar → January), weekdays, units, invoice field labels
   - Inline meter-reading format: `Alg: 9644 Löpp: 9726` → `[Start: 9644, End: 9726]`
 - **12-section analytics dashboard** with trends, MoM/YoY %, unit-price tracking, price-vs-consumption decomposition
-- **One-click PDF export** of the whole dashboard (client-side, no server round-trip)
-- **Optional Claude API fallback** for higher-accuracy extraction, toggled by `PARSER_BACKEND=claude`
+- **One-click PDF export** of the whole dashboard (client-side, no server round-trip) — paginates at chart boundaries so charts are never split mid-body
 
 ## Architecture
 
@@ -110,8 +113,8 @@ python3 -m venv venv
 Backend is now at **http://localhost:8000**.
 
 Backend env vars:
-- `PARSER_BACKEND=tesseract` *(default)* — open-source, local, no API key
-- `PARSER_BACKEND=claude` — Anthropic Claude API, requires `ANTHROPIC_API_KEY`
+- `PARSER_BACKEND=tesseract` *(default)* — open-source, local, no API key. Best on Estonian utility bills and korteriühistu invoices.
+- `PARSER_BACKEND=claude` — Anthropic Claude API, requires `ANTHROPIC_API_KEY`. Works on any invoice format, any language, any layout — use this if the Tesseract parser shows a low-quality warning for your invoice.
 
 ### 4. Start the frontend (in a second terminal)
 
@@ -125,7 +128,7 @@ Open **http://localhost:5173** in your browser. You'll see three tabs: **Upload*
 
 ### 5. Try it
 
-1. Go to **Upload** → drag in a PDF or image of an Estonian utility bill → the parser extracts line items and translates them on the spot.
+1. Go to **Upload** → drag in a PDF or image of your invoice. The local parser handles Estonian utility bills out of the box; for any other format, an amber warning will suggest switching to the Claude backend.
 2. Open the **Bills** tab to see everything stored with expandable per-bill details.
 3. Open **Analytics** to explore 12 dashboard sections — click **Download PDF** to export.
 
@@ -153,6 +156,9 @@ Something else is on port 8000. Either kill it (`lsof -ti:8000 | xargs kill`) or
 
 **Dashboard shows no data**
 Either no bills uploaded yet, or the backend isn't running. Check the **Upload** tab works, or run `python seed_demo.py` to load three sample bills.
+
+**Amber "OCR couldn't read this invoice" warning**
+The local Tesseract parser couldn't extract enough data — typically means the invoice is non-Estonian, has an unusual layout, or is a low-quality scan. Restart the backend with `PARSER_BACKEND=claude ANTHROPIC_API_KEY=sk-ant-... ./venv/bin/uvicorn main:app --port 8000` and re-upload.
 
 ## Parser accuracy
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -86,38 +86,41 @@ def parse_bill_with_claude(file_path: str) -> dict:
     client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
     data, media_type = encode_image(file_path)
 
-    prompt = """You are an expert at reading Estonian utility bills (electricity, gas, water, heating, internet, etc.).
+    prompt = """You are an expert at reading invoices and bills of any type — utilities \
+(electricity, gas, water, heating, internet, waste), subscriptions, services, rent, \
+housing association fees, or any other kind.
 
-Extract structured data from this bill image. Return ONLY a valid JSON object:
+Extract structured data from this invoice. Return ONLY a valid JSON object:
 {
-  "provider": "company name (e.g. Eesti Energia, Elektrilevi, Tallinna Vesi, Gasum, Telia)",
-  "utility_type": "one of: electricity, gas, water, heating, internet, waste, other",
-  "amount_eur": numeric total amount due in euros (e.g. 45.23),
-  "consumption_kwh": numeric kWh if electricity/heating bill (null otherwise),
-  "consumption_m3": numeric m3 if gas/water bill (null otherwise),
+  "provider": "issuing company or supplier name",
+  "utility_type": "best-fit category — one of: electricity, gas, water, heating, internet, waste, other",
+  "amount_eur": numeric total amount due (use the invoice currency; convert symbol to number if needed),
+  "consumption_kwh": numeric kWh consumed if applicable (null otherwise),
+  "consumption_m3": numeric m³ consumed if applicable (null otherwise),
   "bill_date": "YYYY-MM-DD invoice date",
-  "period_start": "YYYY-MM-DD billing period start",
-  "period_end": "YYYY-MM-DD billing period end",
-  "account_number": "customer or account number",
-  "address": "service address",
-  "period": "raw period text as shown on the bill (e.g. 'Veebruar 2026', 'Märts 2026') — do NOT translate",
-  "vat_amount": numeric VAT in euros,
-  "amount_without_vat": numeric amount excluding VAT,
-  "meter_reading_start": numeric opening meter reading,
-  "meter_reading_end": numeric closing meter reading,
+  "period_start": "YYYY-MM-DD billing period start (null if not shown)",
+  "period_end": "YYYY-MM-DD billing period end (null if not shown)",
+  "account_number": "customer / account / contract number",
+  "address": "service or billing address",
+  "period": "raw period text exactly as printed on the invoice — do NOT translate",
+  "vat_amount": numeric VAT/tax amount,
+  "amount_without_vat": numeric subtotal before VAT/tax,
+  "meter_reading_start": numeric opening meter reading if shown,
+  "meter_reading_end": numeric closing meter reading if shown,
   "due_date": "YYYY-MM-DD payment due date",
   "line_items": [
     {
-      "description_et": "Estonian line item text exactly as printed (e.g. 'Elektrienergia', 'Võrgutasu', 'Aktsiis')",
-      "amount_eur": numeric amount for this line,
+      "description_et": "line item description exactly as printed on the invoice",
+      "description_en": "English translation or plain-English rephrasing of the description",
+      "amount_eur": numeric line amount,
       "quantity": numeric quantity,
-      "unit": "kWh / m3 / pcs / etc."
+      "unit": "unit of measure (kWh, m³, pcs, months, etc.)"
     }
   ],
   "confidence": "high/medium/low"
 }
 
-List every charge line visible. Use null for any field you cannot read. Return only the JSON."""
+List every charge line visible. Use null for any field you cannot determine. Return only the JSON."""
 
     if media_type == "application/pdf":
         message = client.messages.create(

--- a/backend/parser.py
+++ b/backend/parser.py
@@ -376,6 +376,16 @@ def parse_bill(path: str) -> dict:
     line_items = extract_line_items(boxes)
 
     kwh, m3 = totals_from_line_items(line_items)
+
+    # Flag poor extraction: no line items and fewer than 3 useful header fields.
+    # This typically means the invoice layout doesn't match the Estonian-specific
+    # regex patterns, and the user should switch to Claude for better results.
+    meaningful_fields = sum(
+        1 for k, v in header.items()
+        if v is not None and v != "" and k not in ("_source",)
+    )
+    _low_quality = len(line_items) == 0 and meaningful_fields < 3
+
     return {
         **header,
         "utility_type": classify(header.get("provider", ""), line_items),
@@ -384,4 +394,5 @@ def parse_bill(path: str) -> dict:
         "consumption_m3": m3,
         "confidence": confidence,
         "_source": source,
+        "_low_quality": _low_quality,
     }

--- a/frontend/src/components/UploadTab.tsx
+++ b/frontend/src/components/UploadTab.tsx
@@ -63,10 +63,10 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
 
   return (
     <div style={{ maxWidth: 640, margin: "0 auto" }}>
-      <h2 style={{ color: "white", marginBottom: 8, fontSize: 22 }}>Upload Utility Bill</h2>
+      <h2 style={{ color: "white", marginBottom: 8, fontSize: 22 }}>Upload Invoice / Bill</h2>
       <p style={{ color: "#9ca3af", marginBottom: 24, fontSize: 14 }}>
-        Tesseract OCR + pdfplumber extract every line item locally — no API key needed.
-        Supports korteriühistu invoices and individual utility bills.
+        Tesseract OCR + pdfplumber extract line items locally — no API key needed.
+        For best results on complex or non-standard invoices, set <code style={{ background: "#252838", padding: "1px 5px", borderRadius: 4, fontSize: 12 }}>PARSER_BACKEND=claude</code>.
       </p>
 
       <div
@@ -127,6 +127,31 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
         )}
       </div>
 
+      {isSuccess && parsed && parsed._low_quality && (
+        <div style={{
+          ...cardStyle,
+          marginTop: 24,
+          borderLeft: "3px solid #f59e0b",
+          background: "#1f1a0e",
+          display: "flex",
+          gap: 12,
+          alignItems: "flex-start",
+        }}>
+          <AlertCircle size={20} color="#f59e0b" style={{ flexShrink: 0, marginTop: 1 }} />
+          <div>
+            <div style={{ color: "#f59e0b", fontWeight: 600, fontSize: 14, marginBottom: 4 }}>
+              OCR couldn't read this invoice
+            </div>
+            <div style={{ color: "#d1d5db", fontSize: 13, lineHeight: 1.5 }}>
+              The local Tesseract parser found very little data — this usually means the invoice
+              layout or language doesn't match the built-in patterns. For accurate extraction and
+              line items, set <code style={{ background: "#252838", padding: "1px 5px", borderRadius: 4 }}>PARSER_BACKEND=claude</code> and
+              re-upload. Claude can read any invoice format, language, or layout.
+            </div>
+          </div>
+        </div>
+      )}
+
       {isSuccess && parsed && (
         <>
           <div style={{ ...cardStyle, marginTop: 24 }}>
@@ -167,11 +192,11 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
 
           {Array.isArray(parsed.line_items) && parsed.line_items.length > 0 ? (
             <div style={{ ...cardStyle, marginTop: 16 }}>
-              <h3 style={{ color: "white", margin: "0 0 12px", fontSize: 14 }}>Line Items (Estonian → English)</h3>
+              <h3 style={{ color: "white", margin: "0 0 12px", fontSize: 14 }}>Line Items</h3>
               <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
                 <thead>
                   <tr style={{ borderBottom: "1px solid #2d3148" }}>
-                    <th style={{ padding: "8px 0", textAlign: "left", color: "#6b7280", fontSize: 11, textTransform: "uppercase", fontWeight: 600 }}>Estonian</th>
+                    <th style={{ padding: "8px 0", textAlign: "left", color: "#6b7280", fontSize: 11, textTransform: "uppercase", fontWeight: 600 }}>Description</th>
                     <th style={{ padding: "8px 0", textAlign: "left", color: "#6b7280", fontSize: 11, textTransform: "uppercase", fontWeight: 600 }}>English</th>
                     <th style={{ padding: "8px 0", textAlign: "right", color: "#6b7280", fontSize: 11, textTransform: "uppercase", fontWeight: 600 }}>Amount</th>
                   </tr>
@@ -209,42 +234,20 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
       )}
 
       <div style={{ ...cardStyle, marginTop: 24 }}>
-        <h3 style={{ color: "white", margin: "0 0 4px", fontSize: 14 }}>Supported Estonian Providers</h3>
-        <p style={{ color: "#6b7280", fontSize: 12, margin: "0 0 12px" }}>Works with any Estonian utility bill. Best accuracy with PDF invoices.</p>
+        <h3 style={{ color: "white", margin: "0 0 4px", fontSize: 14 }}>Supported Invoice Types</h3>
+        <p style={{ color: "#6b7280", fontSize: 12, margin: "0 0 12px" }}>
+          Any invoice or bill can be uploaded. Local OCR works best with standard-layout PDF invoices.
+          Use <code style={{ background: "#252838", padding: "1px 4px", borderRadius: 3 }}>PARSER_BACKEND=claude</code> for
+          non-standard layouts or any language.
+        </p>
 
         <div style={{ marginBottom: 10 }}>
           <div style={{ fontSize: 11, color: "#2563eb", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6, fontWeight: 600 }}>
-            Housing Associations
+            Utility Bills (best OCR accuracy)
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-            {["Korteriühistu (any)", "Building Management"].map(p => (
+            {["Electricity", "Gas", "Water", "Heating", "Internet / Telecom", "Waste Collection", "Housing Association"].map(p => (
               <span key={p} style={{ background: "#1e2640", border: "1px solid #2563eb", borderRadius: 6, padding: "4px 10px", fontSize: 12, color: "#93c5fd" }}>
-                {p}
-              </span>
-            ))}
-          </div>
-        </div>
-
-        <div style={{ marginBottom: 10 }}>
-          <div style={{ fontSize: 11, color: "#9ca3af", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6 }}>
-            Electricity &amp; Gas
-          </div>
-          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-            {["Eesti Energia", "Elektrilevi", "Elering", "Eesti Gaas", "Gasum"].map(p => (
-              <span key={p} style={{ background: "#252838", border: "1px solid #374151", borderRadius: 6, padding: "4px 10px", fontSize: 12, color: "#d1d5db" }}>
-                {p}
-              </span>
-            ))}
-          </div>
-        </div>
-
-        <div style={{ marginBottom: 10 }}>
-          <div style={{ fontSize: 11, color: "#9ca3af", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6 }}>
-            Water, Heating &amp; Telecom
-          </div>
-          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-            {["Tallinna Vesi", "Adven", "Utilitas", "Gren", "Telia", "Elisa", "Tele2"].map(p => (
-              <span key={p} style={{ background: "#252838", border: "1px solid #374151", borderRadius: 6, padding: "4px 10px", fontSize: 12, color: "#d1d5db" }}>
                 {p}
               </span>
             ))}
@@ -253,10 +256,10 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
 
         <div>
           <div style={{ fontSize: 11, color: "#9ca3af", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6 }}>
-            Waste Collection
+            Any invoice (Claude backend)
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-            {["Ragn-Sells", "STS", "Eesti Keskkonnateenused"].map(p => (
+            {["Rent", "Subscriptions", "Services", "Repairs", "Insurance", "Any format or language"].map(p => (
               <span key={p} style={{ background: "#252838", border: "1px solid #374151", borderRadius: 6, padding: "4px 10px", fontSize: 12, color: "#d1d5db" }}>
                 {p}
               </span>


### PR DESCRIPTION
## Summary

- **OCR quality detection**: After Tesseract runs, `parser.py` now computes an extraction quality score. If no line items were found and fewer than 3 header fields extracted, `_low_quality: true` is returned — meaning the invoice layout doesn't match the built-in patterns.
- **Warning banner**: `UploadTab` shows an amber warning when `_low_quality` is true, telling the user to set `PARSER_BACKEND=claude` and re-upload for accurate results.
- **Generalised Claude prompt**: The Claude parser now handles any invoice type, language, or layout — not just Estonian utility bills. It always requests both the original description and an English translation.
- **Generalised UI**: Heading changed to "Upload Invoice / Bill", the provider section now lists invoice categories rather than Estonian-specific provider names, and the line items table says "Description" instead of "Estonian".

## Test plan

- [ ] Upload a standard Estonian utility PDF → no warning should appear, line items extracted
- [ ] Upload a non-Estonian or unusual-layout invoice with Tesseract → amber warning appears with instructions to switch to Claude
- [ ] Set `PARSER_BACKEND=claude` and upload the same non-standard invoice → line items and fields extracted correctly
- [ ] Confirm UI copy no longer mentions "Estonian" in the upload page heading/description

https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG

---
_Generated by [Claude Code](https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG)_