### PR TITLE
Add OpenRouter free AI parser with per-upload model selector

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,10 +1,21 @@
 # Parser backend — one of:
-#   tesseract  (default, fully local, no API key required)
-#   claude     (Anthropic API, requires ANTHROPIC_API_KEY)
+#   tesseract   (default, fully local, no API key required)
+#   claude      (Anthropic API, requires ANTHROPIC_API_KEY)
+#   openrouter  (OpenRouter multi-model API, requires OPENROUTER_API_KEY)
 PARSER_BACKEND=tesseract
 
 # Required when PARSER_BACKEND=claude. Do NOT commit a real key.
 # ANTHROPIC_API_KEY=sk-ant-...
+
+# Required when PARSER_BACKEND=openrouter. Do NOT commit a real key.
+# OPENROUTER_API_KEY=sk-or-v1-...
+# OPENROUTER_MODEL=google/gemini-2.0-flash-exp:free
+
+# Free vision models available on OpenRouter:
+#   google/gemini-2.0-flash-exp:free        (best quality, recommended)
+#   meta-llama/llama-3.2-90b-vision-instruct:free
+#   qwen/qwen2-vl-7b-instruct:free
+#   microsoft/phi-3-vision-128k-instruct:free
 
 # Optional overrides
 # DB_PATH=bills.db

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,18 +7,22 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
 import aiosqlite
-from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from parser import parse_bill as parse_bill_tesseract
+from parser_openrouter import parse_bill_with_openrouter
 from translation import classify_line_item, enrich_parsed
 
 logger = logging.getLogger("utility_tracker")
 logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
 
-# Parser backend: "tesseract" (default, no API key) or "claude" (uses Anthropic API)
+# Parser backend: "tesseract" (default, no API key), "claude" (Anthropic API),
+# or "openrouter" (OpenRouter multi-model API)
 PARSER_BACKEND = os.environ.get("PARSER_BACKEND", "tesseract").lower()
+OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY")
+OPENROUTER_MODEL = os.environ.get("OPENROUTER_MODEL", "google/gemini-2.0-flash-exp:free")
 
 DB_PATH = os.environ.get("DB_PATH", "bills.db")
 UPLOADS_DIR = os.environ.get("UPLOADS_DIR", "uploads")
@@ -202,7 +206,11 @@ List every charge line visible. Use null for any field you cannot determine. Ret
 
 
 @app.post("/api/bills/upload")
-async def upload_bill(file: UploadFile = File(...)):
+async def upload_bill(
+    file: UploadFile = File(...),
+    parser: str | None = Form(None),
+    model: str | None = Form(None),
+):
     if file.content_type not in _ALLOWED_MIME:
         raise HTTPException(400, "Unsupported file type. Upload an image or PDF.")
 
@@ -231,17 +239,24 @@ async def upload_bill(file: UploadFile = File(...)):
                 )
             f.write(chunk)
 
+    effective_parser = (parser or PARSER_BACKEND).lower()
     try:
-        if PARSER_BACKEND == "claude":
+        if effective_parser == "claude":
             parsed = parse_bill_with_claude(save_path)
+        elif effective_parser == "openrouter":
+            parsed = parse_bill_with_openrouter(
+                save_path,
+                api_key=OPENROUTER_API_KEY,
+                model=model or OPENROUTER_MODEL,
+            )
         else:
             parsed = parse_bill_tesseract(save_path)
         parsed = enrich_parsed(parsed)  # add translations locally — no API call
     except Exception:
-        logger.exception("Bill parsing failed for %s (backend=%s)", filename, PARSER_BACKEND)
+        logger.exception("Bill parsing failed for %s (backend=%s)", filename, effective_parser)
         parsed = {
             "error": "Parsing failed — see server logs for details.",
-            "_source": PARSER_BACKEND,
+            "_source": effective_parser,
             "_low_quality": True,
         }
 

--- a/backend/parser_openrouter.py
+++ b/backend/parser_openrouter.py
@@ -1,0 +1,128 @@
+"""
+OpenRouter invoice parser — uses the OpenAI-compatible OpenRouter API.
+
+Supports any vision model available on OpenRouter (free or paid).
+PDF files are rendered to a PNG image first because most free vision models
+only accept image inputs, not raw PDF bytes.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import tempfile
+
+_EXTRACTION_PROMPT = """You are an expert at reading invoices and bills of any type — utilities \
+(electricity, gas, water, heating, internet, waste), subscriptions, services, rent, \
+housing association fees, or any other kind.
+
+Extract structured data from this invoice image. Return ONLY a valid JSON object:
+{
+  "provider": "issuing company or supplier name",
+  "utility_type": "best-fit category — one of: electricity, gas, water, heating, internet, waste, other",
+  "amount_eur": numeric total amount due (use the invoice currency; convert symbol to number if needed),
+  "consumption_kwh": numeric kWh consumed if applicable (null otherwise),
+  "consumption_m3": numeric m³ consumed if applicable (null otherwise),
+  "bill_date": "YYYY-MM-DD invoice date",
+  "period_start": "YYYY-MM-DD billing period start (null if not shown)",
+  "period_end": "YYYY-MM-DD billing period end (null if not shown)",
+  "account_number": "customer / account / contract number",
+  "address": "service or billing address",
+  "period": "raw period text exactly as printed on the invoice — do NOT translate",
+  "vat_amount": numeric VAT/tax amount,
+  "amount_without_vat": numeric subtotal before VAT/tax,
+  "meter_reading_start": numeric opening meter reading if shown,
+  "meter_reading_end": numeric closing meter reading if shown,
+  "due_date": "YYYY-MM-DD payment due date",
+  "line_items": [
+    {
+      "description_et": "line item description exactly as printed on the invoice",
+      "description_en": "English translation or plain-English rephrasing of the description",
+      "amount_eur": numeric line amount,
+      "quantity": numeric quantity,
+      "unit": "unit of measure (kWh, m³, pcs, months, etc.)"
+    }
+  ],
+  "confidence": "high/medium/low"
+}
+
+List every charge line visible. Use null for any field you cannot determine. Return only the JSON."""
+
+
+def _pdf_to_png(pdf_path: str) -> str:
+    """Render the first page of a PDF to a temp PNG. Caller must delete it."""
+    from pdf2image import convert_from_path
+
+    pages = convert_from_path(pdf_path, dpi=200, first_page=1, last_page=1)
+    tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+    pages[0].save(tmp.name, "PNG")
+    tmp.close()
+    return tmp.name
+
+
+def _b64_data_url(path: str) -> str:
+    ext = path.rsplit(".", 1)[-1].lower()
+    mime = "image/png" if ext == "png" else "image/jpeg"
+    with open(path, "rb") as f:
+        data = base64.standard_b64encode(f.read()).decode()
+    return f"data:{mime};base64,{data}"
+
+
+def parse_bill_with_openrouter(
+    file_path: str,
+    api_key: str | None = None,
+    model: str | None = None,
+) -> dict:
+    """Extract invoice data via OpenRouter's OpenAI-compatible API."""
+    from openai import OpenAI
+
+    key = api_key or os.environ.get("OPENROUTER_API_KEY")
+    if not key:
+        raise RuntimeError("OPENROUTER_API_KEY must be set for the openrouter parser.")
+
+    chosen_model = model or os.environ.get("OPENROUTER_MODEL", "google/gemini-2.0-flash-exp:free")
+
+    client = OpenAI(
+        api_key=key,
+        base_url="https://openrouter.ai/api/v1",
+        default_headers={
+            "HTTP-Referer": "https://github.com/osmanhaider/ee-utility-trackly",
+            "X-Title": "EE Utility Trackly",
+        },
+    )
+
+    tmp_path: str | None = None
+    try:
+        if file_path.lower().endswith(".pdf"):
+            tmp_path = _pdf_to_png(file_path)
+            img_path = tmp_path
+        else:
+            img_path = file_path
+
+        data_url = _b64_data_url(img_path)
+
+        response = client.chat.completions.create(
+            model=chosen_model,
+            max_tokens=1500,
+            messages=[{
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": data_url}},
+                    {"type": "text", "text": _EXTRACTION_PROMPT},
+                ],
+            }],
+        )
+    finally:
+        if tmp_path:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+
+    text = (response.choices[0].message.content or "").strip()
+    if text.startswith("```"):
+        text = text.split("```")[1]
+        if text.startswith("json"):
+            text = text[4:]
+        text = text.strip()
+    return json.loads(text)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.136.1
 uvicorn==0.46.0
 python-multipart==0.0.26
 anthropic==0.97.0
+openai>=1.30
 aiosqlite==0.22.1
 pillow==12.2.0
 pdf2image==1.17.0

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -99,9 +99,11 @@ export interface MonthlyTotal {
 }
 
 export const api = {
-  uploadBill: (file: File) => {
+  uploadBill: (file: File, parser?: string, model?: string) => {
     const fd = new FormData();
     fd.append("file", file);
+    if (parser) fd.append("parser", parser);
+    if (model) fd.append("model", model);
     return axios.post<{ id: string; parsed: Record<string, unknown>; replaced: boolean }>(`${BASE}/api/bills/upload`, fd);
   },
   listBills: () => axios.get<Bill[]>(`${BASE}/api/bills`),

--- a/frontend/src/components/UploadTab.tsx
+++ b/frontend/src/components/UploadTab.tsx
@@ -17,12 +17,22 @@ interface UploadTabProps {
 }
 
 type Status = "idle" | "uploading" | "success" | "replaced" | "error";
+type ParserMode = "tesseract" | "openrouter";
+
+const FREE_MODELS = [
+  { id: "google/gemini-2.0-flash-exp:free", label: "Gemini 2.0 Flash (best)" },
+  { id: "meta-llama/llama-3.2-90b-vision-instruct:free", label: "Llama 3.2 90B Vision" },
+  { id: "qwen/qwen2-vl-7b-instruct:free", label: "Qwen2-VL 7B" },
+  { id: "microsoft/phi-3-vision-128k-instruct:free", label: "Phi-3 Vision" },
+];
 
 export default function UploadTab({ onSuccess }: UploadTabProps) {
   const [dragging, setDragging] = useState(false);
   const [status, setStatus] = useState<Status>("idle");
   const [parsed, setParsed] = useState<Record<string, unknown> | null>(null);
   const [errorMsg, setErrorMsg] = useState("");
+  const [parserMode, setParserMode] = useState<ParserMode>("openrouter");
+  const [selectedModel, setSelectedModel] = useState(FREE_MODELS[0].id);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleFile = useCallback(async (file: File) => {
@@ -30,7 +40,11 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
     setParsed(null);
     setErrorMsg("");
     try {
-      const res = await api.uploadBill(file);
+      const res = await api.uploadBill(
+        file,
+        parserMode,
+        parserMode === "openrouter" ? selectedModel : undefined,
+      );
       setParsed(res.data.parsed);
       setStatus(res.data.replaced ? "replaced" : "success");
       setTimeout(onSuccess, 2000);
@@ -39,7 +53,7 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
       setErrorMsg(msg);
       setStatus("error");
     }
-  }, [onSuccess]);
+  }, [onSuccess, parserMode, selectedModel]);
 
   const onDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -65,10 +79,63 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
   return (
     <div style={{ maxWidth: 640, margin: "0 auto" }}>
       <h2 style={{ color: "white", marginBottom: 8, fontSize: 22 }}>Upload Invoice / Bill</h2>
-      <p style={{ color: "#9ca3af", marginBottom: 24, fontSize: 14 }}>
-        Tesseract OCR + pdfplumber extract line items locally — no API key needed.
-        For best results on complex or non-standard invoices, set <code style={{ background: "#252838", padding: "1px 5px", borderRadius: 4, fontSize: 12 }}>PARSER_BACKEND=claude</code>.
+      <p style={{ color: "#9ca3af", marginBottom: 16, fontSize: 14 }}>
+        Choose how to extract data from your invoice, then drop or select the file.
       </p>
+
+      {/* Parser selector */}
+      <div style={{ ...cardStyle, marginBottom: 16, padding: 16 }}>
+        <div style={{ fontSize: 11, color: "#6b7280", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 10, fontWeight: 600 }}>
+          Extraction method
+        </div>
+        <div style={{ display: "flex", gap: 8, marginBottom: parserMode === "openrouter" ? 12 : 0 }}>
+          {([
+            { id: "openrouter", label: "🤖 AI (OpenRouter)", desc: "Free vision models — any invoice, any language" },
+            { id: "tesseract", label: "🔍 Local OCR", desc: "Offline, no API key — best for standard layouts" },
+          ] as { id: ParserMode; label: string; desc: string }[]).map(({ id, label, desc }) => (
+            <button
+              key={id}
+              onClick={() => setParserMode(id)}
+              style={{
+                flex: 1,
+                background: parserMode === id ? "#1e2640" : "#252838",
+                border: `1.5px solid ${parserMode === id ? "#2563eb" : "#374151"}`,
+                borderRadius: 8,
+                padding: "10px 12px",
+                cursor: "pointer",
+                textAlign: "left",
+              }}
+            >
+              <div style={{ color: parserMode === id ? "#93c5fd" : "#e5e7eb", fontSize: 13, fontWeight: 600 }}>{label}</div>
+              <div style={{ color: "#6b7280", fontSize: 11, marginTop: 2 }}>{desc}</div>
+            </button>
+          ))}
+        </div>
+
+        {parserMode === "openrouter" && (
+          <div>
+            <label style={{ fontSize: 12, color: "#9ca3af", display: "block", marginBottom: 4 }}>Model</label>
+            <select
+              value={selectedModel}
+              onChange={(e) => setSelectedModel(e.target.value)}
+              style={{
+                width: "100%",
+                background: "#252838",
+                border: "1px solid #374151",
+                borderRadius: 6,
+                color: "#e5e7eb",
+                padding: "7px 10px",
+                fontSize: 13,
+                cursor: "pointer",
+              }}
+            >
+              {FREE_MODELS.map(m => (
+                <option key={m.id} value={m.id}>{m.label}</option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
 
       <div
         onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
@@ -95,7 +162,9 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
         {status === "uploading" ? (
           <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
             <Loader2 size={40} color="#2563eb" style={{ animation: "spin 1s linear infinite" }} />
-            <p style={{ color: "#9ca3af", margin: 0 }}>Running OCR &amp; extracting line items…</p>
+            <p style={{ color: "#9ca3af", margin: 0 }}>
+              {parserMode === "openrouter" ? "Sending to AI model…" : "Running OCR & extracting line items…"}
+            </p>
           </div>
         ) : status === "replaced" ? (
           <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
@@ -144,10 +213,10 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
               OCR couldn't read this invoice
             </div>
             <div style={{ color: "#d1d5db", fontSize: 13, lineHeight: 1.5 }}>
-              The local Tesseract parser found very little data — this usually means the invoice
-              layout or language doesn't match the built-in patterns. For accurate extraction and
-              line items, set <code style={{ background: "#252838", padding: "1px 5px", borderRadius: 4 }}>PARSER_BACKEND=claude</code> and
-              re-upload. Claude can read any invoice format, language, or layout.
+              The local OCR parser found very little data — this usually means the invoice
+              layout or language doesn't match the built-in patterns. Switch to{" "}
+              <strong style={{ color: "#93c5fd" }}>AI (OpenRouter)</strong> above and re-upload
+              for accurate extraction from any invoice format or language.
             </div>
           </div>
         </div>
@@ -237,14 +306,13 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
       <div style={{ ...cardStyle, marginTop: 24 }}>
         <h3 style={{ color: "white", margin: "0 0 4px", fontSize: 14 }}>Supported Invoice Types</h3>
         <p style={{ color: "#6b7280", fontSize: 12, margin: "0 0 12px" }}>
-          Any invoice or bill can be uploaded. Local OCR works best with standard-layout PDF invoices.
-          Use <code style={{ background: "#252838", padding: "1px 4px", borderRadius: 3 }}>PARSER_BACKEND=claude</code> for
-          non-standard layouts or any language.
+          Local OCR works best with standard-layout PDF invoices.
+          AI (OpenRouter) handles any format, language, or layout using free vision models.
         </p>
 
         <div style={{ marginBottom: 10 }}>
           <div style={{ fontSize: 11, color: "#2563eb", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6, fontWeight: 600 }}>
-            Utility Bills (best OCR accuracy)
+            Utility Bills (best local OCR accuracy)
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
             {["Electricity", "Gas", "Water", "Heating", "Internet / Telecom", "Waste Collection", "Housing Association"].map(p => (
@@ -257,7 +325,7 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
 
         <div>
           <div style={{ fontSize: 11, color: "#9ca3af", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6 }}>
-            Any invoice (Claude backend)
+            Any invoice (AI / OpenRouter)
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
             {["Rent", "Subscriptions", "Services", "Repairs", "Insurance", "Any format or language"].map(p => (


### PR DESCRIPTION
## Summary

- Adds **OpenRouter** as a new parser backend — free vision models, no credit card needed
- Users pick the parser and model **per upload** directly in the UI (no env var change needed)
- Your `OPENROUTER_API_KEY` is stored in `backend/.env` (gitignored)

## What changed

### Backend
- **`backend/parser_openrouter.py`** (new) — OpenAI-compatible client pointing at `https://openrouter.ai/api/v1`; PDFs are rendered to PNG before sending since most free vision models don't accept raw PDF bytes
- **`backend/main.py`** — upload endpoint now accepts optional `parser` and `model` form fields; adds `OPENROUTER_API_KEY` / `OPENROUTER_MODEL` env vars
- **`backend/requirements.txt`** — added `openai>=1.30` (OpenRouter uses the same SDK)
- **`backend/.env.example`** — documents `openrouter` backend + free model options

### Frontend
- **`frontend/src/api.ts`** — `uploadBill()` forwards `parser` + `model` as form fields
- **`frontend/src/components/UploadTab.tsx`** — parser toggle (AI / Local OCR) + model dropdown with four free OpenRouter vision models; defaults to **Gemini 2.0 Flash free**

## Free models available in the UI
| Model | Notes |
|---|---|
| `google/gemini-2.0-flash-exp:free` | Best quality, recommended |
| `meta-llama/llama-3.2-90b-vision-instruct:free` | Strong alternative |
| `qwen/qwen2-vl-7b-instruct:free` | Compact, good quality |
| `microsoft/phi-3-vision-128k-instruct:free` | Lightweight |

## Test plan
- [ ] Upload a PDF with AI / Gemini 2.0 Flash — structured data + line items extracted
- [ ] Switch to Local OCR — Tesseract path used, no API call
- [ ] Upload unsupported layout with Local OCR — amber low-quality warning shown, suggests switching to AI
- [ ] Switch model in dropdown — different model used for next upload

https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG

---
_Generated by [Claude Code](https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG)_