### PR TITLE
Add Vercel + Render free-tier deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,46 @@ ANTHROPIC_API_KEY=sk-ant-... PARSER_BACKEND=claude docker compose up --build
 
 Open **http://localhost:5173**. Uploads and the SQLite DB are persisted in a named volume (`backend-data`).
 
+## Deploy (free tier)
+
+A free-tier cloud setup: **Vercel** for the frontend, **Render** for the backend.
+
+> ⚠️ The API has no authentication. Anyone with the Render URL can upload bills and delete records. Treat any deployment as a personal demo, not a shared service.
+
+### 1. Backend on Render
+
+1. Log in to [Render](https://render.com) → **New** → **Web Service** → pick this repo.
+2. Settings:
+   - **Root Directory**: `backend`
+   - **Environment**: `Docker` (uses `backend/Dockerfile`)
+   - **Instance Type**: `Free`
+3. Add environment variables:
+   - `PARSER_BACKEND` = `openrouter`
+   - `OPENROUTER_API_KEY` = your key from https://openrouter.ai/keys
+   - `OPENROUTER_MODEL` = `google/gemini-2.0-flash-exp:free` *(optional; overridable per upload)*
+4. Click **Create Web Service**. First build takes ~5 min. Copy the generated URL (e.g. `https://ee-utility-trackly.onrender.com`).
+
+The free tier spins down after 15 minutes of inactivity. The first request after a cold start takes ~30 s. The SQLite DB lives on the ephemeral disk and resets on every redeploy — for persistence, migrate to Supabase Postgres.
+
+### 2. Frontend on Vercel
+
+1. Log in to [Vercel](https://vercel.com) → **Add New** → **Project** → import this repo.
+2. Settings:
+   - **Root Directory**: `frontend`
+   - **Framework**: `Vite` *(auto-detected)*
+3. Environment variable:
+   - `VITE_API_URL` = the Render URL from step 1 (no trailing slash)
+4. Click **Deploy**. Your app is live at `https://<project>.vercel.app`.
+
+The bundled `frontend/vercel.json` provides SPA routing so deep links / refreshes don't 404.
+
+### 3. CORS
+
+The backend accepts requests from `*.vercel.app` by default. For a custom domain, set `CORS_ALLOW_ORIGINS` on the Render service:
+```
+CORS_ALLOW_ORIGINS=https://bills.example.com,https://www.bills.example.com
+```
+
 ## Run locally
 
 ### Prerequisites

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,3 +22,8 @@ PARSER_BACKEND=tesseract
 # UPLOADS_DIR=uploads
 # MAX_UPLOAD_BYTES=20971520    # 20 MB
 # LOG_LEVEL=INFO
+
+# CORS — defaults cover localhost:5173/4173 and any *.vercel.app host.
+# Override if you have a custom domain or want stricter rules.
+# CORS_ALLOW_ORIGINS=http://localhost:5173,https://mycustomdomain.com
+# CORS_ALLOW_ORIGIN_REGEX=https://.*\.vercel\.app

--- a/backend/main.py
+++ b/backend/main.py
@@ -80,9 +80,21 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Estonia Utility Bill Tracker", lifespan=lifespan)
 
+# CORS. Defaults cover local dev + any *.vercel.app deployment (each
+# preview branch gets its own hostname, so wildcarding avoids having to
+# list them). Override CORS_ALLOW_ORIGINS / CORS_ALLOW_ORIGIN_REGEX for
+# stricter production rules or to add a custom domain.
+_DEFAULT_CORS_ORIGINS = "http://localhost:5173,http://localhost:4173"
+_DEFAULT_CORS_ORIGIN_REGEX = r"https://.*\.vercel\.app"
+CORS_ALLOW_ORIGINS = [
+    o.strip() for o in os.environ.get("CORS_ALLOW_ORIGINS", _DEFAULT_CORS_ORIGINS).split(",") if o.strip()
+]
+CORS_ALLOW_ORIGIN_REGEX = os.environ.get("CORS_ALLOW_ORIGIN_REGEX", _DEFAULT_CORS_ORIGIN_REGEX) or None
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://localhost:4173"],
+    allow_origins=CORS_ALLOW_ORIGINS,
+    allow_origin_regex=CORS_ALLOW_ORIGIN_REGEX,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary

Enables deploying the app free of charge on:
- **Vercel Hobby** for the frontend
- **Render free web service** for the backend (uses the existing `backend/Dockerfile`)

## Changes

### `frontend/vercel.json` (new)
- SPA rewrites so refreshes and deep links don't 404

### `backend/main.py`
- CORS is now env-driven with sensible defaults:
  - `CORS_ALLOW_ORIGINS` — comma-separated exact-match list (defaults to localhost dev ports)
  - `CORS_ALLOW_ORIGIN_REGEX` — regex (defaults to `https://.*\.vercel\.app` so every preview URL works without per-branch config)
- Override either for a custom domain

### `backend/.env.example`
- Documents the two new CORS variables

### `README.md`
- New **Deploy (free tier)** section with step-by-step Render + Vercel instructions
- Explicit warning that the app has no auth — treat any deployment as a personal demo

## Deployment playbook (from the README)

1. **Render** → New Web Service → root `backend`, Docker, free tier, set `OPENROUTER_API_KEY` env var. Copy the generated URL.
2. **Vercel** → Import repo → root `frontend`, Vite auto-detected, set `VITE_API_URL` = Render URL. Deploy.
3. For a custom domain, set `CORS_ALLOW_ORIGINS=https://your.domain` on Render.

## Test plan
- [ ] Local dev still works (localhost:5173 → localhost:8000)
- [ ] `CORS_ALLOW_ORIGINS` override does not break localhost dev
- [ ] After deploying: upload a bill on Vercel URL → CORS passes, OpenRouter parser runs
- [ ] After deploying: SPA deep link (e.g. `/bills`) refreshes without 404

https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG

---
_Generated by [Claude Code](https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG)_