### PR TITLE
Add shared-password login gate for public deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Two extraction backends are available:
   - Inline meter-reading format: `Alg: 9644 Löpp: 9726` → `[Start: 9644, End: 9726]`
 - **12-section analytics dashboard** with trends, MoM/YoY %, unit-price tracking, price-vs-consumption decomposition
 - **One-click PDF export** of the whole dashboard (client-side, no server round-trip) — paginates at chart boundaries so charts are never split mid-body
+- **Optional shared-password login** gate for deployed instances (disabled by default for local dev)
 
 ## Architecture
 
@@ -57,7 +58,7 @@ Open **http://localhost:5173**. Uploads and the SQLite DB are persisted in a nam
 
 A free-tier cloud setup: **Vercel** for the frontend, **Render** for the backend.
 
-> ⚠️ The API has no authentication. Anyone with the Render URL can upload bills and delete records. Treat any deployment as a personal demo, not a shared service.
+> ⚠️ The demo uses a **single shared password** — fine for a personal deployment but not a real multi-user product. Treat it as a personal demo, not a shared service. For a public-grade deployment, swap this for proper OAuth or Cloudflare Access.
 
 ### 1. Backend on Render
 
@@ -70,6 +71,11 @@ A free-tier cloud setup: **Vercel** for the frontend, **Render** for the backend
    - `PARSER_BACKEND` = `openrouter`
    - `OPENROUTER_API_KEY` = your key from https://openrouter.ai/keys
    - `OPENROUTER_MODEL` = `google/gemini-2.0-flash-exp:free` *(optional; overridable per upload)*
+   - `APP_PASSWORD` = any password you'll type at the login screen
+   - `AUTH_SECRET` = a long random hex string — generate locally with:
+     ```
+     python -c "import secrets; print(secrets.token_hex(32))"
+     ```
 4. Click **Create Web Service**. First build takes ~5 min. Copy the generated URL (e.g. `https://ee-utility-trackly.onrender.com`).
 
 The free tier spins down after 15 minutes of inactivity. The first request after a cold start takes ~30 s. The SQLite DB lives on the ephemeral disk and resets on every redeploy — for persistence, migrate to Supabase Postgres.
@@ -92,6 +98,12 @@ The backend accepts requests from `*.vercel.app` by default. For a custom domain
 ```
 CORS_ALLOW_ORIGINS=https://bills.example.com,https://www.bills.example.com
 ```
+
+### 4. Login
+
+Visiting the Vercel URL will show a password prompt. Enter the `APP_PASSWORD` you set on Render. The token is stored in `localStorage` and lasts 7 days (override with `TOKEN_TTL_SEC`). To rotate the password, change `APP_PASSWORD` on Render — existing tokens stay valid until they expire unless you also rotate `AUTH_SECRET` (which invalidates every token immediately).
+
+For local development, leave `APP_PASSWORD` unset and the login screen is skipped entirely.
 
 ## Run locally
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,3 +27,10 @@ PARSER_BACKEND=tesseract
 # Override if you have a custom domain or want stricter rules.
 # CORS_ALLOW_ORIGINS=http://localhost:5173,https://mycustomdomain.com
 # CORS_ALLOW_ORIGIN_REGEX=https://.*\.vercel\.app
+
+# Auth (shared-password demo login). Leave APP_PASSWORD empty to disable
+# auth entirely — useful for local dev. In any public deployment set both.
+# Generate AUTH_SECRET with: python -c "import secrets; print(secrets.token_hex(32))"
+# APP_PASSWORD=change-me
+# AUTH_SECRET=replace-with-long-random-hex
+# TOKEN_TTL_SEC=604800   # 7 days

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,75 @@
+"""Simple shared-password auth for demo deployments.
+
+Tokens are HMAC-SHA256 signed payloads (`base64url(json).hex-sig`). No
+database, no user model, no JWT dependency — just enough to keep a
+public Render URL from being scraped by anyone with the link.
+
+Environment:
+    APP_PASSWORD   Shared password. Required for auth to be active.
+    AUTH_SECRET    HMAC signing secret. Required when APP_PASSWORD is set.
+    TOKEN_TTL_SEC  Optional. Token lifetime in seconds (default 7 days).
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+
+
+class AuthError(Exception):
+    pass
+
+
+APP_PASSWORD = os.environ.get("APP_PASSWORD", "")
+AUTH_SECRET = os.environ.get("AUTH_SECRET", "")
+TOKEN_TTL_SEC = int(os.environ.get("TOKEN_TTL_SEC", 7 * 24 * 3600))
+
+
+def auth_enabled() -> bool:
+    return bool(APP_PASSWORD)
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def create_token(ttl_sec: int | None = None) -> str:
+    if not AUTH_SECRET:
+        raise AuthError("AUTH_SECRET is not configured")
+    payload = {"exp": int(time.time()) + (ttl_sec or TOKEN_TTL_SEC)}
+    payload_b64 = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    sig = hmac.new(AUTH_SECRET.encode(), payload_b64.encode(), hashlib.sha256).hexdigest()
+    return f"{payload_b64}.{sig}"
+
+
+def verify_token(token: str) -> dict:
+    if not AUTH_SECRET:
+        raise AuthError("AUTH_SECRET is not configured")
+    try:
+        payload_b64, sig = token.split(".", 1)
+    except ValueError as e:
+        raise AuthError("malformed token") from e
+    expected = hmac.new(AUTH_SECRET.encode(), payload_b64.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        raise AuthError("invalid signature")
+    try:
+        payload = json.loads(_b64url_decode(payload_b64))
+    except (ValueError, json.JSONDecodeError) as e:
+        raise AuthError("invalid payload") from e
+    if int(payload.get("exp", 0)) < int(time.time()):
+        raise AuthError("token expired")
+    return payload
+
+
+def verify_password(candidate: str) -> bool:
+    if not APP_PASSWORD:
+        return False
+    return hmac.compare_digest(candidate.encode(), APP_PASSWORD.encode())

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,10 +9,12 @@ from datetime import datetime, timezone
 
 import aiosqlite
 import httpx
-from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+import auth as auth_mod
 from parser import parse_bill as parse_bill_tesseract
 from parser_openrouter import parse_bill_with_openrouter_chain
 from translation import classify_line_item, enrich_parsed
@@ -99,6 +101,65 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+# Paths that bypass the bearer-token check even when auth is active.
+# `/api/auth/login` must be reachable so users can obtain a token;
+# `/api/auth/status` lets the frontend detect whether auth is enabled
+# at all before showing a login screen.
+_AUTH_EXEMPT_PATHS = frozenset({
+    "/api/auth/login",
+    "/api/auth/status",
+})
+
+
+@app.middleware("http")
+async def auth_middleware(request: Request, call_next):
+    # CORS preflights must pass through untouched — the browser strips
+    # custom headers (including Authorization) before sending them.
+    if request.method == "OPTIONS":
+        return await call_next(request)
+    if not auth_mod.auth_enabled():
+        return await call_next(request)
+    path = request.url.path
+    if not path.startswith("/api/") or path in _AUTH_EXEMPT_PATHS:
+        return await call_next(request)
+    header = request.headers.get("authorization", "")
+    if not header.lower().startswith("bearer "):
+        return JSONResponse({"detail": "Missing bearer token"}, status_code=401)
+    try:
+        auth_mod.verify_token(header[7:].strip())
+    except auth_mod.AuthError as e:
+        return JSONResponse({"detail": f"Invalid token: {e}"}, status_code=401)
+    return await call_next(request)
+
+
+if auth_mod.auth_enabled() and not auth_mod.AUTH_SECRET:
+    raise RuntimeError(
+        "APP_PASSWORD is set but AUTH_SECRET is missing. "
+        "Generate one with `python -c 'import secrets; print(secrets.token_hex(32))'` "
+        "and set it as AUTH_SECRET."
+    )
+
+
+class LoginRequest(BaseModel):
+    password: str
+
+
+@app.get("/api/auth/status")
+async def auth_status():
+    """Lets the frontend know if a login screen is needed."""
+    return {"auth_required": auth_mod.auth_enabled()}
+
+
+@app.post("/api/auth/login")
+async def auth_login(body: LoginRequest):
+    if not auth_mod.auth_enabled():
+        # Return a token anyway so the frontend behaves consistently.
+        return {"token": "disabled", "auth_required": False}
+    if not auth_mod.verify_password(body.password):
+        raise HTTPException(401, "Invalid password")
+    return {"token": auth_mod.create_token(), "auth_required": True}
 
 
 class BillUpdate(BaseModel):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,4 +22,4 @@ ignore = [
 # (test_parser.py, test_december.py, test_pdf.py) are stand-alone
 # integration scripts that run OCR at import time — they're kept as
 # manual smoke-tests and are not executed by CI.
-testpaths = ["test_claude_parser.py"]
+testpaths = ["test_claude_parser.py", "test_auth.py"]

--- a/backend/test_auth.py
+++ b/backend/test_auth.py
@@ -1,0 +1,99 @@
+"""Unit tests for the shared-password auth module."""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+def _reload_auth(monkeypatch, *, password: str = "", secret: str = "", ttl: int | None = None):
+    if password:
+        monkeypatch.setenv("APP_PASSWORD", password)
+    else:
+        monkeypatch.delenv("APP_PASSWORD", raising=False)
+    if secret:
+        monkeypatch.setenv("AUTH_SECRET", secret)
+    else:
+        monkeypatch.delenv("AUTH_SECRET", raising=False)
+    if ttl is not None:
+        monkeypatch.setenv("TOKEN_TTL_SEC", str(ttl))
+    else:
+        monkeypatch.delenv("TOKEN_TTL_SEC", raising=False)
+    import auth
+    return importlib.reload(auth)
+
+
+def test_auth_disabled_when_password_unset(monkeypatch):
+    auth = _reload_auth(monkeypatch)
+    assert auth.auth_enabled() is False
+
+
+def test_auth_enabled_when_password_set(monkeypatch):
+    auth = _reload_auth(monkeypatch, password="hunter2", secret="x" * 64)
+    assert auth.auth_enabled() is True
+
+
+def test_verify_password_constant_time(monkeypatch):
+    auth = _reload_auth(monkeypatch, password="hunter2", secret="x" * 64)
+    assert auth.verify_password("hunter2") is True
+    assert auth.verify_password("wrong") is False
+    assert auth.verify_password("") is False
+
+
+def test_token_roundtrip(monkeypatch):
+    auth = _reload_auth(monkeypatch, password="hunter2", secret="x" * 64)
+    tok = auth.create_token()
+    payload = auth.verify_token(tok)
+    assert payload["exp"] > int(time.time())
+
+
+def test_token_tampered_signature_rejected(monkeypatch):
+    auth = _reload_auth(monkeypatch, password="hunter2", secret="x" * 64)
+    tok = auth.create_token()
+    body, sig = tok.rsplit(".", 1)
+    tampered = f"{body}.{'0' * len(sig)}"
+    with pytest.raises(auth.AuthError):
+        auth.verify_token(tampered)
+
+
+def test_token_tampered_payload_rejected(monkeypatch):
+    auth = _reload_auth(monkeypatch, password="hunter2", secret="x" * 64)
+    tok = auth.create_token()
+    body, sig = tok.rsplit(".", 1)
+    # Flip the last character of the payload — signature should no longer match.
+    flipped_char = "A" if body[-1] != "A" else "B"
+    tampered = body[:-1] + flipped_char + "." + sig
+    with pytest.raises(auth.AuthError):
+        auth.verify_token(tampered)
+
+
+def test_token_expired(monkeypatch):
+    auth = _reload_auth(monkeypatch, password="hunter2", secret="x" * 64)
+    tok = auth.create_token(ttl_sec=-1)
+    with pytest.raises(auth.AuthError, match="expired"):
+        auth.verify_token(tok)
+
+
+def test_token_malformed(monkeypatch):
+    auth = _reload_auth(monkeypatch, password="hunter2", secret="x" * 64)
+    with pytest.raises(auth.AuthError):
+        auth.verify_token("not-a-real-token")
+
+
+def test_secret_required_for_create(monkeypatch):
+    auth = _reload_auth(monkeypatch, password="hunter2")  # no secret
+    with pytest.raises(auth.AuthError):
+        auth.create_token()
+
+
+def test_different_secrets_produce_incompatible_tokens(monkeypatch):
+    auth = _reload_auth(monkeypatch, password="hunter2", secret="secret-a" * 8)
+    tok = auth.create_token()
+    auth2 = _reload_auth(monkeypatch, password="hunter2", secret="secret-b" * 8)
+    with pytest.raises(auth2.AuthError):
+        auth2.verify_token(tok)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,79 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import UploadTab from "./components/UploadTab";
 import BillsTab from "./components/BillsTab";
 import AnalyticsTab from "./components/AnalyticsTab";
 import HelpTab from "./components/HelpTab";
+import LoginScreen from "./components/LoginScreen";
 import ErrorBoundary from "./components/ErrorBoundary";
-import { BarChart2, Receipt, Upload, HelpCircle } from "lucide-react";
+import { BarChart2, Receipt, Upload, HelpCircle, LogOut } from "lucide-react";
+import { api } from "./api";
+import { clearToken, getToken } from "./auth";
 
 type Tab = "upload" | "bills" | "analytics" | "help";
+type AuthState = "loading" | "required" | "authed" | "disabled";
 
 export default function App() {
   const [tab, setTab] = useState<Tab>("upload");
   const [refreshKey, setRefreshKey] = useState(0);
+  const [authState, setAuthState] = useState<AuthState>("loading");
 
   const refresh = () => setRefreshKey((k) => k + 1);
+
+  // On mount, ask the backend whether auth is required. If it isn't we
+  // skip the login screen entirely (local-dev convenience). If it is
+  // and we already have a stored token, trust it — the axios interceptor
+  // will bounce us back to login on 401 if the token has expired.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getAuthStatus()
+      .then((res) => {
+        if (cancelled) return;
+        if (!res.data.auth_required) {
+          setAuthState("disabled");
+        } else if (getToken()) {
+          setAuthState("authed");
+        } else {
+          setAuthState("required");
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setAuthState(getToken() ? "authed" : "required");
+      });
+    const onLogout = () => setAuthState("required");
+    window.addEventListener("auth:logout", onLogout);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("auth:logout", onLogout);
+    };
+  }, []);
+
+  const logout = () => {
+    clearToken();
+    setAuthState("required");
+  };
+
+  if (authState === "loading") {
+    return (
+      <div
+        style={{
+          minHeight: "100vh",
+          background: "#0f1117",
+          color: "#9ca3af",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (authState === "required") {
+    return <LoginScreen onSuccess={() => setAuthState("authed")} />;
+  }
 
   return (
     <div style={{ minHeight: "100vh", background: "#0f1117", color: "#e5e7eb", fontFamily: "system-ui, sans-serif" }}>
@@ -26,7 +87,7 @@ export default function App() {
             <div style={{ fontSize: 12, color: "#9ca3af" }}>Estonia Monthly Bill Analytics</div>
           </div>
         </div>
-        <nav style={{ marginLeft: "auto", display: "flex", gap: 4 }}>
+        <nav style={{ marginLeft: "auto", display: "flex", gap: 4, alignItems: "center" }}>
           {([
             ["upload", "Upload", Upload],
             ["bills", "Bills", Receipt],
@@ -48,6 +109,20 @@ export default function App() {
               {label}
             </button>
           ))}
+          {authState === "authed" && (
+            <button
+              onClick={logout}
+              title="Sign out"
+              style={{
+                display: "flex", alignItems: "center", gap: 8, padding: "8px 12px",
+                borderRadius: 8, border: "1px solid #2d3148", cursor: "pointer", fontSize: 13,
+                background: "transparent", color: "#9ca3af", marginLeft: 8,
+              }}
+            >
+              <LogOut size={14} />
+              Sign out
+            </button>
+          )}
         </nav>
       </header>
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,31 @@
 import axios from "axios";
+import { clearToken, getToken } from "./auth";
 
 const BASE = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
+
+// Attach the bearer token to every outgoing request (when present) and
+// log the user out automatically on 401 so a stale token can't pin the
+// UI to a broken state.
+axios.interceptors.request.use((config) => {
+  const token = getToken();
+  if (token) {
+    config.headers = config.headers ?? {};
+    config.headers["Authorization"] = `Bearer ${token}`;
+  }
+  return config;
+});
+
+axios.interceptors.response.use(
+  (r) => r,
+  (err) => {
+    if (err?.response?.status === 401) {
+      clearToken();
+      // Nudge the app to re-render; LoginScreen listens for this.
+      window.dispatchEvent(new Event("auth:logout"));
+    }
+    return Promise.reject(err);
+  },
+);
 
 export interface Bill {
   id: string;
@@ -114,4 +139,7 @@ export const api = {
     axios.get<{ models: { id: string; label: string }[]; cached?: boolean; error?: string }>(
       `${BASE}/api/openrouter-models`
     ),
+  getAuthStatus: () => axios.get<{ auth_required: boolean }>(`${BASE}/api/auth/status`),
+  login: (password: string) =>
+    axios.post<{ token: string; auth_required: boolean }>(`${BASE}/api/auth/login`, { password }),
 };

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -1,0 +1,26 @@
+const KEY = "ee-utility-trackly:token";
+
+export function getToken(): string | null {
+  try {
+    return localStorage.getItem(KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setToken(token: string): void {
+  try {
+    localStorage.setItem(KEY, token);
+  } catch {
+    // localStorage disabled (private mode) — token won't persist but the
+    // session is still valid for the current page load.
+  }
+}
+
+export function clearToken(): void {
+  try {
+    localStorage.removeItem(KEY);
+  } catch {
+    // no-op
+  }
+}

--- a/frontend/src/components/LoginScreen.tsx
+++ b/frontend/src/components/LoginScreen.tsx
@@ -1,0 +1,135 @@
+import { useState } from "react";
+import { Lock } from "lucide-react";
+import axios from "axios";
+import { api } from "../api";
+import { setToken } from "../auth";
+
+interface Props {
+  onSuccess: () => void;
+}
+
+export default function LoginScreen({ onSuccess }: Props) {
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await api.login(password);
+      setToken(res.data.token);
+      onSuccess();
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response?.status === 401) {
+        setError("Wrong password.");
+      } else {
+        setError("Could not reach the server. Check your connection.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "#0f1117",
+        color: "#e5e7eb",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: "system-ui, sans-serif",
+        padding: 24,
+      }}
+    >
+      <form
+        onSubmit={submit}
+        style={{
+          background: "#1a1d27",
+          border: "1px solid #2d3148",
+          borderRadius: 12,
+          padding: 32,
+          width: "100%",
+          maxWidth: 400,
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div
+            style={{
+              width: 40,
+              height: 40,
+              background: "#2563eb",
+              borderRadius: 8,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Lock size={20} color="white" />
+          </div>
+          <div>
+            <div style={{ fontSize: 18, fontWeight: 700, color: "white" }}>Sign in</div>
+            <div style={{ fontSize: 12, color: "#9ca3af" }}>EE Utility Tracker</div>
+          </div>
+        </div>
+
+        <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <span style={{ fontSize: 13, color: "#9ca3af" }}>Password</span>
+          <input
+            type="password"
+            autoFocus
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={loading}
+            style={{
+              padding: "10px 12px",
+              borderRadius: 8,
+              border: "1px solid #2d3148",
+              background: "#0f1117",
+              color: "#e5e7eb",
+              fontSize: 14,
+            }}
+          />
+        </label>
+
+        {error && (
+          <div
+            style={{
+              padding: "8px 12px",
+              borderRadius: 6,
+              background: "#3a1111",
+              border: "1px solid #7f1d1d",
+              color: "#fca5a5",
+              fontSize: 13,
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading || !password}
+          style={{
+            padding: "10px 16px",
+            borderRadius: 8,
+            border: "none",
+            cursor: loading || !password ? "not-allowed" : "pointer",
+            background: loading || !password ? "#1e3a8a" : "#2563eb",
+            color: "white",
+            fontWeight: 600,
+            fontSize: 14,
+          }}
+        >
+          {loading ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a single-password login screen so a public Vercel + Render deployment isn't wide open to anyone who stumbles on the URL. Scope is intentionally demo-sized — one shared password, 7-day localStorage token, no user accounts.

## How it works

1. User hits the site → frontend calls `GET /api/auth/status`
   - `auth_required: false` → app renders normally (local dev when `APP_PASSWORD` is unset)
   - `auth_required: true` → login screen is shown
2. User enters password → `POST /api/auth/login` returns an HMAC-SHA256 signed token
3. Token stored in `localStorage`, axios interceptor attaches `Authorization: Bearer <token>` on every request
4. Backend middleware verifies the token on all `/api/*` routes except `/api/auth/login` and `/api/auth/status`
5. On 401, interceptor clears the token and bumps the user back to the login screen

## Backend — `backend/auth.py` (new)

- Stdlib-only: `hmac` + `hashlib` + `base64`, **no new dependency** (no PyJWT)
- Token format: `base64url({"exp": unix_ts}).hex-hmac-sha256`
- Constant-time comparisons (`hmac.compare_digest`) for both password check and signature verification
- `APP_PASSWORD` unset → `auth_enabled()` returns False → middleware no-ops (frictionless local dev)
- Set `APP_PASSWORD` but forget `AUTH_SECRET` → backend refuses to start with an actionable error

## Backend — middleware

- Placed after CORS so preflight `OPTIONS` requests pass through untouched (browsers strip custom headers on preflight)
- Only guards `/api/*`; `/docs`, `/openapi.json`, static assets unaffected

## Frontend

- `src/auth.ts` — `getToken` / `setToken` / `clearToken` helpers (localStorage-wrapped for private-mode safety)
- `src/api.ts` — axios interceptors:
  - request: attach `Authorization` when token present
  - response: on 401, clear token + dispatch `auth:logout` event
- `src/components/LoginScreen.tsx` — password form, shows "Wrong password" on 401 / "Could not reach the server" on network error
- `src/App.tsx` — three-state auth flow (`loading` / `required` / `authed` / `disabled`), sign-out button in header

## Tests

`backend/test_auth.py` — 10 new unit tests:
- Token roundtrip
- Tampered signature rejected
- Tampered payload rejected (signature invalidates)
- Expired token rejected
- Malformed token rejected
- Secret required to create
- Cross-secret tokens rejected
- `auth_enabled()` reflects `APP_PASSWORD` presence
- `verify_password()` correctness

Integration-probed locally with `TestClient`:
- `GET /api/bills` without token → 401
- Wrong password → 401
- Right password → 200 + token
- Bearer `{token}` → 200 (passes through to route handler)
- Tampered token → 401 with `"Invalid token: invalid signature"`
- `OPTIONS` preflight → 200 without auth

## Deploy changes

On Render, add two env vars alongside the existing `OPENROUTER_API_KEY`:
- `APP_PASSWORD` = any password you'll type at the login screen
- `AUTH_SECRET` = 64-char hex generated with `python -c "import secrets; print(secrets.token_hex(32))"`

To rotate: change `APP_PASSWORD` (existing tokens stay valid until expiry) or `AUTH_SECRET` (invalidates every token immediately).

## Test plan

- [ ] Local: leave `APP_PASSWORD` unset → login screen skipped entirely
- [ ] Local: set `APP_PASSWORD=test` + `AUTH_SECRET=...` → login screen appears, wrong password shows error, correct password logs in
- [ ] Token persists across page refresh (localStorage)
- [ ] Sign-out button clears token and shows login
- [ ] Deployed on Render + Vercel: unauthed visitors see login screen
- [ ] `curl -H "Authorization: Bearer bogus" .../api/bills` → 401

https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG

---
_Generated by [Claude Code](https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG)_