### PR TITLE
Keep upload error banner visible when AI parsing fails

### DIFF
--- a/frontend/src/components/UploadTab.tsx
+++ b/frontend/src/components/UploadTab.tsx
@@ -71,7 +71,11 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
       const res = await api.uploadBill(file, parserMode, effectiveModel || undefined);
       setParsed(res.data.parsed);
       setStatus(res.data.replaced ? "replaced" : "success");
-      setTimeout(onSuccess, 2000);
+      // If parsing failed, keep the user on this tab so they can read the
+      // error and pick a different model. They can navigate to Bills manually.
+      if (!res.data.parsed?._low_quality) {
+        setTimeout(onSuccess, 2000);
+      }
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : "Upload failed";
       setErrorMsg(msg);
@@ -227,9 +231,19 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
           </div>
         ) : status === "success" ? (
           <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-            <CheckCircle size={40} color="#22c55e" />
-            <p style={{ color: "#22c55e", margin: 0, fontWeight: 600 }}>Bill uploaded successfully!</p>
-            <p style={{ color: "#9ca3af", margin: 0, fontSize: 13 }}>Redirecting to bills list…</p>
+            {parsed?._low_quality ? (
+              <>
+                <AlertCircle size={40} color="#f59e0b" />
+                <p style={{ color: "#f59e0b", margin: 0, fontWeight: 600 }}>File saved, but data couldn't be extracted</p>
+                <p style={{ color: "#9ca3af", margin: 0, fontSize: 13 }}>See details below — try a different model or upload again</p>
+              </>
+            ) : (
+              <>
+                <CheckCircle size={40} color="#22c55e" />
+                <p style={{ color: "#22c55e", margin: 0, fontWeight: 600 }}>Bill uploaded successfully!</p>
+                <p style={{ color: "#9ca3af", margin: 0, fontSize: 13 }}>Redirecting to bills list…</p>
+              </>
+            )}
           </div>
         ) : status === "error" ? (
           <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>


### PR DESCRIPTION
## Summary

The upload tab auto-redirects to the Bills tab 2 seconds after a successful HTTP upload, regardless of whether the AI model actually extracted any data. That meant when OpenRouter returned an error (rate-limited, delisted model, non-JSON response), the warning banner flashed for ~1 second and then vanished as the page navigated away.

## Fix

`frontend/src/components/UploadTab.tsx`:
1. Skip the `setTimeout(onSuccess, 2000)` redirect when `parsed._low_quality` is set — the user needs time to read the error and pick a different model.
2. When the payload is low-quality, swap the big green check + "Bill uploaded successfully!" header for an amber alert + "File saved, but data couldn't be extracted" so the failure is obvious at a glance (the green banner on top of an amber banner was confusing).

The file is still saved to the DB either way (the user can see it in Bills and manually fill in fields), but they'll stay on the upload page long enough to re-try with a different model.

## Test plan

- [ ] Upload a bill with a working model → green success banner, auto-redirect to Bills (unchanged)
- [ ] Upload with a deliberately broken model ID (e.g. `foo/bar:free`) → amber warning stays on screen, error code visible, no redirect
- [ ] Click on any tab manually to leave the page → still works

https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG

---
_Generated by [Claude Code](https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG)_