### PR TITLE
Position OpenRouter free AI as the primary non-local parser in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@
 
 Upload any invoice or bill (image or PDF), get it parsed into structured line items, and explore spending patterns through a 12-section analytics dashboard.
 
-Two extraction backends are available:
+Three extraction backends are available:
 - **Local OCR** *(default)* — Tesseract + `pdfplumber`, optimized for Estonian utility bills. Runs entirely locally, no API key required.
-- **Claude API** *(optional)* — handles any invoice type, any language, any layout. Set `PARSER_BACKEND=claude`.
+- **Free AI via OpenRouter** *(recommended for non-Estonian or unusual invoices)* — pick any free vision model (Gemini, Gemma, Llama, Qwen…) per upload. Requires a free OpenRouter key. Set `PARSER_BACKEND=openrouter`.
+- **Claude API** *(premium alternative)* — highest accuracy, paid. Set `PARSER_BACKEND=claude`.
 
 ## Features
 
-- **Two extraction backends** — local OCR for Estonian utility bills, Claude API for anything else (rent, subscriptions, services, non-Estonian invoices, scanned docs with unusual layouts)
-- **Automatic quality detection** — if the local OCR can't read the invoice, the UI shows a warning banner directing the user to switch to the Claude backend
+- **Three extraction backends** — local OCR for Estonian utility bills, free AI (OpenRouter) for anything else (rent, subscriptions, services, non-Estonian invoices, scanned docs with unusual layouts), Claude API as a premium option
+- **Per-upload model picker** — the UI fetches OpenRouter's live list of free vision models, the user picks one at upload time, and the backend auto-falls-back through up to 4 models if the first one is delisted or rate-limited
+- **Automatic quality detection** — if the local OCR can't read the invoice, the UI shows a warning banner directing the user to switch to an AI model
 - **Open-source OCR pipeline**: Tesseract for images, `pdfplumber` for native-text PDFs, `pdf2image` + OCR fallback for scanned PDFs
 - **Hardcoded Estonian→English dictionary** (~180 terms) — no API call needed for translation when using the local backend
   - Utility services: electricity, gas, water, heating, telecom, waste
@@ -48,9 +50,14 @@ Two extraction backends are available:
 # Tesseract backend (default):
 docker compose up --build
 
-# Claude backend:
+# Free AI via OpenRouter (recommended for non-Estonian invoices):
+OPENROUTER_API_KEY=sk-or-v1-... PARSER_BACKEND=openrouter docker compose up --build
+
+# Claude backend (paid):
 ANTHROPIC_API_KEY=sk-ant-... PARSER_BACKEND=claude docker compose up --build
 ```
+
+> 💡 Get a free OpenRouter key at https://openrouter.ai/keys — no credit card required. It unlocks every `:free` vision model (Gemini 2.0 Flash, Gemma 3, Llama 3.2 Vision, Qwen-VL, etc.).
 
 Open **http://localhost:5173**. Uploads and the SQLite DB are persisted in a named volume (`backend-data`).
 
@@ -164,8 +171,7 @@ which pdftoppm                # must print a path
 ```bash
 cd backend
 python3 -m venv venv
-./venv/bin/pip install fastapi uvicorn python-multipart anthropic aiosqlite \
-                      pillow pdf2image pytesseract pdfplumber
+./venv/bin/pip install -r requirements.txt
 
 # Optional — seed 3 demo bills so the dashboard is populated immediately
 ./venv/bin/python seed_demo.py
@@ -178,14 +184,17 @@ Backend is now at **http://localhost:8000**.
 
 Backend env vars (see `backend/.env.example` for the full list):
 - `PARSER_BACKEND=tesseract` *(default)* — open-source, local, no API key. Best on Estonian utility bills and korteriühistu invoices.
-- `PARSER_BACKEND=claude` — Anthropic Claude API, requires `ANTHROPIC_API_KEY`. Works on any invoice format, any language, any layout — use this if the Tesseract parser shows a low-quality warning for your invoice.
+- `PARSER_BACKEND=openrouter` — free AI vision models via OpenRouter, requires `OPENROUTER_API_KEY` (free, no credit card). Works on any invoice format, any language, any layout — use this if the Tesseract parser shows a low-quality warning. Optionally set `OPENROUTER_MODEL` (any `:free` vision model ID) as the default; users can still override it per upload in the UI.
+- `PARSER_BACKEND=claude` — Anthropic Claude API, requires `ANTHROPIC_API_KEY` (paid). Highest accuracy; use only if the free OpenRouter models aren't getting the job done.
+- `APP_PASSWORD` — optional shared-password login gate. Unset = no login required.
+- `AUTH_SECRET` — required when `APP_PASSWORD` is set. 64-char hex, generate with `python -c "import secrets; print(secrets.token_hex(32))"`.
 - `MAX_UPLOAD_BYTES` — hard cap on upload size in bytes (default 20 MB).
 - `DB_PATH`, `UPLOADS_DIR`, `LOG_LEVEL` — override storage paths and log verbosity.
 
 Frontend env var (see `frontend/.env.example`):
 - `VITE_API_URL` — base URL of the backend. Defaults to `http://localhost:8000`.
 
-> ⚠️ **Security**: the API has no authentication. Run locally only — do not expose it to the public internet without adding an auth layer (reverse proxy with basic auth, Cloudflare Access, etc.).
+> ⚠️ **Security**: for local development the API has no authentication. For deployed instances, set `APP_PASSWORD` + `AUTH_SECRET` to enable the built-in shared-password login screen (see **Deploy** section above). For multi-user production, swap for proper OAuth or Cloudflare Access.
 
 ### 4. Start the frontend (in a second terminal)
 
@@ -199,7 +208,7 @@ Open **http://localhost:5173** in your browser. You'll see three tabs: **Upload*
 
 ### 5. Try it
 
-1. Go to **Upload** → drag in a PDF or image of your invoice. The local parser handles Estonian utility bills out of the box; for any other format, an amber warning will suggest switching to the Claude backend.
+1. Go to **Upload** → pick an extraction method (🔍 Local OCR or 🤖 AI / OpenRouter) and drag in your invoice. The local parser handles Estonian utility bills out of the box; for any other format, switch to the AI tab and pick any free vision model from the dropdown.
 2. Open the **Bills** tab to see everything stored with expandable per-bill details.
 3. Open **Analytics** to explore 12 dashboard sections — click **Download PDF** to export.
 
@@ -214,9 +223,7 @@ The Estonian language pack is missing. On macOS: `brew install tesseract-lang`. 
 **`pip install` fails with `401 Error, Credentials not correct`**
 Your pip is pointing at a private corporate index (e.g. AWS CodeArtifact). Bypass it for this one command:
 ```bash
-./venv/bin/pip install --index-url https://pypi.org/simple/ \
-    fastapi uvicorn python-multipart anthropic aiosqlite \
-    pillow pdf2image pytesseract pdfplumber
+./venv/bin/pip install --index-url https://pypi.org/simple/ -r requirements.txt
 ```
 
 **`Failed to fetch` / CORS error in browser**
@@ -229,7 +236,13 @@ Something else is on port 8000. Either kill it (`lsof -ti:8000 | xargs kill`) or
 Either no bills uploaded yet, or the backend isn't running. Check the **Upload** tab works, or run `python seed_demo.py` to load three sample bills.
 
 **Amber "OCR couldn't read this invoice" warning**
-The local Tesseract parser couldn't extract enough data — typically means the invoice is non-Estonian, has an unusual layout, or is a low-quality scan. Restart the backend with `PARSER_BACKEND=claude ANTHROPIC_API_KEY=sk-ant-... ./venv/bin/uvicorn main:app --port 8000` and re-upload.
+The local Tesseract parser couldn't extract enough data — typically means the invoice is non-Estonian, has an unusual layout, or is a low-quality scan. Switch the **Extraction method** toggle on the Upload tab to **🤖 AI (OpenRouter)** and re-upload — no restart needed. Requires `OPENROUTER_API_KEY` to be set (free key at https://openrouter.ai/keys).
+
+**Amber "File saved, but data couldn't be extracted" after AI upload**
+The selected OpenRouter model failed (rate-limited, delisted from the free tier, or returned a non-JSON response). The error text in the banner tells you which. Pick a different model from the dropdown and try again — the backend auto-falls-back through up to 4 free models, so transient failures usually resolve on the next attempt.
+
+**`RuntimeError: OPENROUTER_API_KEY must be set for the openrouter parser`**
+The backend can't see your OpenRouter key. For local dev, copy `backend/.env.example` to `backend/.env` and fill in `OPENROUTER_API_KEY=sk-or-v1-...` — then restart `uvicorn`. For deployed instances, add the env var in Render's dashboard and wait for the automatic redeploy.
 
 ## Parser accuracy
 
@@ -244,6 +257,7 @@ Tested on real Tallinn korteriühistu invoices:
 
 Native-text PDFs give **high confidence** (pdfplumber, 100% character accuracy).
 Scanned PDFs and images give **medium confidence** (Tesseract OCR, occasional accent drops).
+For non-Estonian or non-standard invoices, switch to the **AI (OpenRouter)** backend — free vision models typically match Claude's accuracy on invoices they're given.
 
 ## Dashboard sections
 
@@ -279,9 +293,13 @@ Glossary (`backend/translation.py`) includes:
 backend/
 ├── main.py              FastAPI app, SQLite schema, analytics endpoint
 ├── parser.py            Tesseract OCR + pdfplumber + regex + column detector
+├── parser_openrouter.py OpenRouter client + auto-fallback chain across free vision models
+├── auth.py              Shared-password login (HMAC-signed tokens, stdlib only)
 ├── translation.py       180-term Estonian→English glossary + period parser
 ├── seed_demo.py         Seed 3 sample bills without any API call
 ├── render_preview.py    ASCII preview of the dashboard
+├── test_auth.py         Unit tests for token roundtrip, tampering, expiry
+├── test_claude_parser.py  Unit tests for the Claude parser branch
 ├── test_parser.py       End-to-end test on synthetic PNG
 ├── test_december.py     Validation on the December 2025 bill format
 └── test_pdf.py          Validation on native-text PDFs


### PR DESCRIPTION
## Summary

The README still described Claude as the default AI option, even though the app has supported OpenRouter free models for several PRs now and that's what users without a paid API budget will reach for. This PR reframes the docs so OpenRouter is the main recommended path for non-Estonian invoices, with Claude kept as a premium alternative.

## What changed

- **Intro**: Two-backend blurb → three-backend breakdown (Local OCR / 🤖 OpenRouter / Claude), with OpenRouter marked as recommended for non-Estonian or unusual invoices.
- **Features list**: calls out the per-upload model picker + auto-fallback chain (up to 4 models).
- **Docker quickstart**: adds the `PARSER_BACKEND=openrouter` snippet alongside the Claude one; notes that OpenRouter keys are free with no credit card.
- **Local dev install**: replaces the long `pip install` line with `pip install -r requirements.txt` so new deps (openai, httpx) don't drift out of sync with the docs.
- **Backend env var reference**: documents `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, `APP_PASSWORD`, `AUTH_SECRET`.
- **Security note** (Run locally section): points users at the built-in shared-password login for deployments instead of just warning them off.
- **Troubleshooting**: new entries
  - _"File saved, but data couldn't be extracted"_ → model delisted / rate-limited, pick another from dropdown
  - _`RuntimeError: OPENROUTER_API_KEY must be set`_ → how to set the key in local `.env` and on Render
  - Old _"Amber OCR warning"_ entry now points at the in-UI AI toggle instead of restarting the backend with a different env var.
- **Directory layout**: adds `parser_openrouter.py`, `auth.py`, `test_auth.py`, `test_claude_parser.py`.

## Test plan

Docs-only change — no code touched.

- [ ] Render the README on GitHub, check all three backends are clearly discoverable
- [ ] Follow the Docker OpenRouter snippet from a fresh clone → app boots with AI parser selectable

https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG

---
_Generated by [Claude Code](https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG)_