### PR TITLE
Optimise layout for mobile browsers

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import { BarChart2, Receipt, Upload, HelpCircle, LogOut } from "lucide-react";
 import { api } from "./api";
 import { clearToken, getToken } from "./auth";
+import { useIsMobile } from "./hooks/useIsMobile";
 
 type Tab = "upload" | "bills" | "analytics" | "help";
 type AuthState = "loading" | "required" | "authed" | "disabled";
@@ -16,6 +17,7 @@ export default function App() {
   const [tab, setTab] = useState<Tab>("upload");
   const [refreshKey, setRefreshKey] = useState(0);
   const [authState, setAuthState] = useState<AuthState>("loading");
+  const isMobile = useIsMobile();
 
   const refresh = () => setRefreshKey((k) => k + 1);
 
@@ -77,17 +79,23 @@ export default function App() {
 
   return (
     <div style={{ minHeight: "100vh", background: "#0f1117", color: "#e5e7eb", fontFamily: "system-ui, sans-serif" }}>
-      <header style={{ background: "#1a1d27", borderBottom: "1px solid #2d3148", padding: "16px 24px", display: "flex", alignItems: "center", gap: "16px" }}>
-        <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
-          <div style={{ width: 36, height: 36, background: "#2563eb", borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center" }}>
-            <Receipt size={18} color="white" />
+      <header style={{
+        background: "#1a1d27", borderBottom: "1px solid #2d3148",
+        padding: isMobile ? "12px 16px" : "16px 24px",
+        display: "flex", alignItems: "center", gap: isMobile ? 8 : 16,
+      }}>
+        <div style={{ display: "flex", alignItems: "center", gap: isMobile ? 8 : 12 }}>
+          <div style={{ width: 32, height: 32, background: "#2563eb", borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+            <Receipt size={16} color="white" />
           </div>
-          <div>
-            <div style={{ fontSize: 16, fontWeight: 700, color: "white" }}>EE Utility Tracker</div>
-            <div style={{ fontSize: 12, color: "#9ca3af" }}>Estonia Monthly Bill Analytics</div>
-          </div>
+          {!isMobile && (
+            <div>
+              <div style={{ fontSize: 16, fontWeight: 700, color: "white" }}>EE Utility Tracker</div>
+              <div style={{ fontSize: 12, color: "#9ca3af" }}>Estonia Monthly Bill Analytics</div>
+            </div>
+          )}
         </div>
-        <nav style={{ marginLeft: "auto", display: "flex", gap: 4, alignItems: "center" }}>
+        <nav style={{ marginLeft: "auto", display: "flex", gap: isMobile ? 2 : 4, alignItems: "center" }}>
           {([
             ["upload", "Upload", Upload],
             ["bills", "Bills", Receipt],
@@ -97,16 +105,19 @@ export default function App() {
             <button
               key={id}
               onClick={() => setTab(id)}
+              title={label}
               style={{
-                display: "flex", alignItems: "center", gap: 8, padding: "8px 16px",
-                borderRadius: 8, border: "none", cursor: "pointer", fontSize: 14, fontWeight: 500,
+                display: "flex", alignItems: "center", gap: 6,
+                padding: isMobile ? "8px 10px" : "8px 14px",
+                borderRadius: 8, border: "none", cursor: "pointer",
+                fontSize: 13, fontWeight: 500,
                 background: tab === id ? "#2563eb" : "transparent",
                 color: tab === id ? "white" : "#9ca3af",
                 transition: "all 0.15s",
               }}
             >
               <Icon size={16} />
-              {label}
+              {!isMobile && label}
             </button>
           ))}
           {authState === "authed" && (
@@ -114,19 +125,21 @@ export default function App() {
               onClick={logout}
               title="Sign out"
               style={{
-                display: "flex", alignItems: "center", gap: 8, padding: "8px 12px",
-                borderRadius: 8, border: "1px solid #2d3148", cursor: "pointer", fontSize: 13,
-                background: "transparent", color: "#9ca3af", marginLeft: 8,
+                display: "flex", alignItems: "center", gap: 6,
+                padding: isMobile ? "8px 10px" : "8px 12px",
+                borderRadius: 8, border: "1px solid #2d3148", cursor: "pointer",
+                fontSize: 13, background: "transparent", color: "#9ca3af",
+                marginLeft: isMobile ? 4 : 8,
               }}
             >
               <LogOut size={14} />
-              Sign out
+              {!isMobile && "Sign out"}
             </button>
           )}
         </nav>
       </header>
 
-      <main style={{ padding: "24px", maxWidth: 1280, margin: "0 auto" }}>
+      <main style={{ padding: isMobile ? "16px 12px" : "24px", maxWidth: 1280, margin: "0 auto" }}>
         <ErrorBoundary>
           {tab === "upload" && <UploadTab onSuccess={() => { refresh(); setTab("bills"); }} />}
           {tab === "bills" && <BillsTab key={refreshKey} />}

--- a/frontend/src/components/AnalyticsTab.tsx
+++ b/frontend/src/components/AnalyticsTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useIsMobile } from "../hooks/useIsMobile";
 import { api, type AnalyticsSummary } from "../api";
 import {
   LineChart, Line, BarChart, Bar, PieChart, Pie, Cell, RadarChart, Radar,
@@ -181,6 +182,7 @@ export default function AnalyticsTab() {
   const [loading, setLoading] = useState(true);
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
+  const isMobile = useIsMobile();
   const dashboardRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -438,7 +440,8 @@ export default function AnalyticsTab() {
   }
   const liStackData = Object.values(liStackRows).sort((a, b) => String(a.month).localeCompare(String(b.month)));
 
-  const grid2 = { display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(340px, 1fr))", gap: 20 };
+  const grid2 = { display: "grid", gridTemplateColumns: isMobile ? "1fr" : "repeat(auto-fill, minmax(340px, 1fr))", gap: isMobile ? 12 : 20 };
+  const chartH = (base: number) => isMobile ? Math.round(base * 0.75) : base;
 
   return (
     <div>
@@ -541,7 +544,7 @@ export default function AnalyticsTab() {
       <SectionTitle>📈 1. Monthly Spending Trend &amp; Rolling Average</SectionTitle>
       <div style={grid2}>
         <ChartCard title="Total Monthly Spend — Line" subtitle="Clean line chart of monthly total with labeled points">
-          <ResponsiveContainer width="100%" height={260}>
+          <ResponsiveContainer width="100%" height={chartH(260)}>
             <LineChart data={data.monthly_total} margin={{ top: 20, right: 20, left: 0, bottom: 5 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#2d3148" vertical={false} />
               <XAxis dataKey="month" tick={{ fill: "#94a3b8", fontSize: 11 }} tickFormatter={fmtMonthShort} interval="preserveStartEnd" minTickGap={24} />
@@ -577,7 +580,7 @@ export default function AnalyticsTab() {
         </ChartCard>
 
         <ChartCard title="Total Monthly Spend — Area" subtitle="Filled area view · Dashed line = 3-month rolling average">
-          <ResponsiveContainer width="100%" height={260}>
+          <ResponsiveContainer width="100%" height={chartH(260)}>
             <AreaChart data={data.monthly_total}>
               <defs>
                 <linearGradient id="totalGrad" x1="0" y1="0" x2="0" y2="1">
@@ -604,7 +607,7 @@ export default function AnalyticsTab() {
           <div style={grid2}>
             {momRows.length > 0 && (
               <ChartCard title="Month-over-Month Change" subtitle="Green = cheaper than previous month · Red = more expensive">
-                <ResponsiveContainer width="100%" height={260}>
+                <ResponsiveContainer width="100%" height={chartH(260)}>
                   <BarChart data={momRows}>
                     <CartesianGrid strokeDasharray="3 3" stroke="#2d3148" vertical={false} />
                     <XAxis dataKey="month" tick={{ fill: "#94a3b8", fontSize: 11 }} tickFormatter={fmtMonthShort} interval="preserveStartEnd" minTickGap={24} />
@@ -622,7 +625,7 @@ export default function AnalyticsTab() {
 
             {yoyRows.length > 0 && (
               <ChartCard title="Year-over-Year Change" subtitle="Green = cheaper than same month last year · Red = more expensive">
-                <ResponsiveContainer width="100%" height={260}>
+                <ResponsiveContainer width="100%" height={chartH(260)}>
                   <BarChart data={yoyRows}>
                     <CartesianGrid strokeDasharray="3 3" stroke="#2d3148" vertical={false} />
                     <XAxis dataKey="month" tick={{ fill: "#94a3b8", fontSize: 11 }} tickFormatter={fmtMonthShort} interval="preserveStartEnd" minTickGap={24} />
@@ -679,7 +682,7 @@ export default function AnalyticsTab() {
       <SectionTitle>🗂️ 3. Spend Breakdown by Utility Type</SectionTitle>
       <div style={grid2}>
         <ChartCard title="Monthly Stacked by Type" subtitle="See which utilities drive costs each month">
-          <ResponsiveContainer width="100%" height={320}>
+          <ResponsiveContainer width="100%" height={chartH(320)}>
             <BarChart data={stackedRows} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#2d3148" vertical={false} />
               <XAxis dataKey="month" tick={{ fill: "#94a3b8", fontSize: 11 }} tickFormatter={fmtMonthShort} interval="preserveStartEnd" minTickGap={24} />
@@ -694,7 +697,7 @@ export default function AnalyticsTab() {
         </ChartCard>
 
         <ChartCard title="Share of Total Spend" subtitle="Cumulative share per category">
-          <ResponsiveContainer width="100%" height={320}>
+          <ResponsiveContainer width="100%" height={chartH(320)}>
             <PieChart>
               <Pie
                 data={data.by_type}
@@ -742,7 +745,7 @@ export default function AnalyticsTab() {
       <SectionTitle>🌡️ 4. Seasonal Cost Patterns</SectionTitle>
       <div style={grid2}>
         <ChartCard title="Average Bill by Calendar Month" subtitle="Reveals heating spikes in winter, A/C in summer">
-          <ResponsiveContainer width="100%" height={320}>
+          <ResponsiveContainer width="100%" height={chartH(320)}>
             <BarChart data={seasonalRows} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#2d3148" vertical={false} />
               <XAxis dataKey="month" tick={{ fill: "#94a3b8", fontSize: 11 }} tickFormatter={fmtMonthShort} interval="preserveStartEnd" minTickGap={24} />
@@ -757,7 +760,7 @@ export default function AnalyticsTab() {
         </ChartCard>
 
         <ChartCard title="Seasonal Radar Profile" subtitle="Shape = energy use pattern across 4 seasons">
-          <ResponsiveContainer width="100%" height={320}>
+          <ResponsiveContainer width="100%" height={chartH(320)}>
             <RadarChart data={radarData} cx="50%" cy="45%" outerRadius={75}>
               <PolarGrid stroke="#2d3148" />
               <PolarAngleAxis dataKey="season" tick={{ fill: "#9ca3af", fontSize: 12 }} />
@@ -776,7 +779,7 @@ export default function AnalyticsTab() {
         <>
           <SectionTitle>📅 5. Annual Spend Comparison</SectionTitle>
           <ChartCard title="Annual Spend by Category" subtitle="Compare total utility cost across years">
-            <ResponsiveContainer width="100%" height={320}>
+            <ResponsiveContainer width="100%" height={chartH(320)}>
               <BarChart data={annualRows} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#2d3148" vertical={false} />
                 <XAxis dataKey="year" tick={{ fill: "#6b7280", fontSize: 12 }} />
@@ -797,11 +800,11 @@ export default function AnalyticsTab() {
         <>
           <SectionTitle>🏢 6. Spend by Provider</SectionTitle>
           <ChartCard title="Top Providers by Total Spend" subtitle="Identify your most expensive suppliers">
-            <ResponsiveContainer width="100%" height={220}>
+            <ResponsiveContainer width="100%" height={chartH(220)}>
               <BarChart data={topProviders} layout="vertical">
                 <CartesianGrid strokeDasharray="3 3" stroke="#2d3148" horizontal={false} />
                 <XAxis type="number" tick={{ fill: "#6b7280", fontSize: 12 }} tickFormatter={v => `€${v}`} />
-                <YAxis type="category" dataKey="provider" tick={{ fill: "#9ca3af", fontSize: 12 }} width={120} />
+                <YAxis type="category" dataKey="provider" tick={{ fill: "#9ca3af", fontSize: isMobile ? 10 : 12 }} width={isMobile ? 80 : 120} />
                 <Tooltip content={<RichTooltip unit="€" />} cursor={{ fill: "rgba(148,163,184,0.08)" }} />
                 <Bar dataKey="total_eur" fill="#2563eb" name="Total Spend" radius={[0, 4, 4, 0]}>
                   {topProviders.map((_, i) => <Cell key={i} fill={PALETTE[i % PALETTE.length]} />)}
@@ -815,7 +818,7 @@ export default function AnalyticsTab() {
       {/* 7. Per-type trend lines */}
       <SectionTitle>📊 7. Per-Utility Trend Lines</SectionTitle>
       <ChartCard title="Each Utility Type Over Time" subtitle="A sudden spike = price change or leak">
-        <ResponsiveContainer width="100%" height={340}>
+        <ResponsiveContainer width="100%" height={chartH(340)}>
           <LineChart data={stackedRows} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#2d3148" vertical={false} />
             <XAxis dataKey="month" tick={{ fill: "#94a3b8", fontSize: 11 }} tickFormatter={fmtMonthShort} interval="preserveStartEnd" minTickGap={24} />
@@ -832,7 +835,8 @@ export default function AnalyticsTab() {
       {/* 8. Summary stats table */}
       <SectionTitle>🔢 8. Summary Statistics by Type</SectionTitle>
       <div style={{ background: "#1a1d27", border: "1px solid #2d3148", borderRadius: 12, overflow: "hidden" }}>
-        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14 }}>
+        <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14, minWidth: 520 }}>
           <thead>
             <tr style={{ borderBottom: "1px solid #2d3148" }}>
               {["Type", "Bills", "Total", "Avg/Month", "Min", "Max", "Consumption"].map(h => (
@@ -861,6 +865,7 @@ export default function AnalyticsTab() {
             ))}
           </tbody>
         </table>
+        </div>
       </div>
 
       {/* 9. Line-item unit price trends */}
@@ -871,7 +876,7 @@ export default function AnalyticsTab() {
             title="Price per Unit Over Time"
             subtitle={`Top ${priceVaryingLabels.length} most-varying unit prices — reveals tariff hikes independent of consumption`}
           >
-            <ResponsiveContainer width="100%" height={340}>
+            <ResponsiveContainer width="100%" height={chartH(340)}>
               <LineChart data={unitPriceRows} margin={{ top: 10, right: 20, left: 0, bottom: 5 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#2d3148" vertical={false} />
                 <XAxis dataKey="month" tick={{ fill: "#94a3b8", fontSize: 11 }} tickFormatter={fmtMonthShort} interval="preserveStartEnd" minTickGap={24} />

--- a/frontend/src/components/BillsTab.tsx
+++ b/frontend/src/components/BillsTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api, type Bill } from "../api";
 import { Trash2, ChevronDown, ChevronUp, AlertCircle, Loader2 } from "lucide-react";
+import { useIsMobile } from "../hooks/useIsMobile";
 
 const UTILITY_ICONS: Record<string, string> = {
   electricity: "⚡", gas: "🔥", water: "💧",
@@ -41,8 +42,9 @@ export default function BillsTab() {
 
   const totalEur = filtered.reduce((s, b) => s + (b.amount_eur ?? 0), 0);
 
+  const isMobile = useIsMobile();
   const cardStyle = { background: "#1a1d27", borderRadius: 12, border: "1px solid #2d3148" };
-  const inputStyle = { background: "#252838", border: "1px solid #374151", borderRadius: 6, color: "#e5e7eb", padding: "6px 12px", fontSize: 13 };
+  const inputStyle = { background: "#252838", border: "1px solid #374151", borderRadius: 6, color: "#e5e7eb", padding: "6px 10px", fontSize: 13 };
 
   if (loading) return (
     <div style={{ display: "flex", justifyContent: "center", alignItems: "center", height: 200, gap: 12, color: "#9ca3af" }}>
@@ -89,36 +91,36 @@ export default function BillsTab() {
             <div key={bill.id} style={{ ...cardStyle, overflow: "hidden" }}>
               <div
                 onClick={() => setExpanded(isOpen ? null : bill.id)}
-                style={{ padding: "16px 20px", cursor: "pointer", display: "flex", alignItems: "center", gap: 16 }}
+                style={{ padding: isMobile ? "12px 14px" : "16px 20px", cursor: "pointer", display: "flex", alignItems: "center", gap: isMobile ? 10 : 16 }}
               >
-                <div style={{ width: 40, height: 40, borderRadius: 8, background: `${color}22`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 20, flexShrink: 0 }}>
+                <div style={{ width: 36, height: 36, borderRadius: 8, background: `${color}22`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 18, flexShrink: 0 }}>
                   {UTILITY_ICONS[bill.utility_type ?? "other"] ?? "📄"}
                 </div>
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                    <span style={{ fontWeight: 600, color: "white", fontSize: 15 }}>{bill.provider ?? "Unknown Provider"}</span>
-                    {bill.utility_type && (
+                  <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                    <span style={{ fontWeight: 600, color: "white", fontSize: isMobile ? 14 : 15 }}>{bill.provider ?? "Unknown Provider"}</span>
+                    {bill.utility_type && !isMobile && (
                       <span style={{ fontSize: 11, padding: "2px 8px", borderRadius: 20, background: `${color}22`, color, border: `1px solid ${color}44`, textTransform: "capitalize" }}>
                         {bill.utility_type}
                       </span>
                     )}
                   </div>
-                  <div style={{ fontSize: 13, color: "#9ca3af", marginTop: 2 }}>
+                  <div style={{ fontSize: 12, color: "#9ca3af", marginTop: 2 }}>
                     {bill.bill_date ?? bill.upload_date?.slice(0, 10)}
-                    {bill.period_start && bill.period_end && ` · ${bill.period_start} → ${bill.period_end}`}
+                    {bill.period_start && bill.period_end && !isMobile && ` · ${bill.period_start} → ${bill.period_end}`}
                   </div>
                 </div>
-                <div style={{ textAlign: "right", marginRight: 8 }}>
-                  <div style={{ fontWeight: 700, fontSize: 18, color: "#22c55e" }}>
+                <div style={{ textAlign: "right", flexShrink: 0 }}>
+                  <div style={{ fontWeight: 700, fontSize: isMobile ? 15 : 18, color: "#22c55e" }}>
                     {bill.amount_eur != null ? `€${bill.amount_eur.toFixed(2)}` : "—"}
                   </div>
-                  {bill.consumption_kwh != null && <div style={{ fontSize: 12, color: "#9ca3af" }}>{bill.consumption_kwh} kWh</div>}
-                  {bill.consumption_m3 != null && <div style={{ fontSize: 12, color: "#9ca3af" }}>{bill.consumption_m3} m³</div>}
+                  {bill.consumption_kwh != null && !isMobile && <div style={{ fontSize: 12, color: "#9ca3af" }}>{bill.consumption_kwh} kWh</div>}
+                  {bill.consumption_m3 != null && !isMobile && <div style={{ fontSize: 12, color: "#9ca3af" }}>{bill.consumption_m3} m³</div>}
                 </div>
-                <button onClick={e => deleteBill(bill.id, e)} style={{ background: "none", border: "none", cursor: "pointer", color: "#6b7280", padding: 4, borderRadius: 4 }}>
-                  <Trash2 size={16} />
+                <button onClick={e => deleteBill(bill.id, e)} style={{ background: "none", border: "none", cursor: "pointer", color: "#6b7280", padding: 4, borderRadius: 4, flexShrink: 0 }}>
+                  <Trash2 size={15} />
                 </button>
-                {isOpen ? <ChevronUp size={16} color="#6b7280" /> : <ChevronDown size={16} color="#6b7280" />}
+                {isOpen ? <ChevronUp size={15} color="#6b7280" style={{ flexShrink: 0 }} /> : <ChevronDown size={15} color="#6b7280" style={{ flexShrink: 0 }} />}
               </div>
 
               {isOpen && (
@@ -158,7 +160,8 @@ export default function BillsTab() {
                       <div style={{ fontSize: 11, color: "#6b7280", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 8, fontWeight: 600 }}>
                         Line Items (Estonian → English)
                       </div>
-                      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+                      <div style={{ overflowX: "auto" }}>
+                      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13, minWidth: 360 }}>
                         <thead>
                           <tr style={{ borderBottom: "1px solid #2d3148" }}>
                             <th style={{ padding: "6px 0", textAlign: "left", color: "#6b7280", fontSize: 11, fontWeight: 600 }}>ESTONIAN</th>
@@ -178,6 +181,7 @@ export default function BillsTab() {
                           ))}
                         </tbody>
                       </table>
+                      </div>
                     </div>
                   )}
 

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from "react";
+
+export function useIsMobile(breakpoint = 640) {
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < breakpoint);
+  useEffect(() => {
+    const handler = () => setIsMobile(window.innerWidth < breakpoint);
+    window.addEventListener("resize", handler, { passive: true });
+    return () => window.removeEventListener("resize", handler);
+  }, [breakpoint]);
+  return isMobile;
+}


### PR DESCRIPTION
## Summary

Makes the app usable on mobile browsers (375–640 px) without breaking the desktop experience.

## Changes

### `frontend/src/hooks/useIsMobile.ts` (new)
Simple resize-aware hook: returns `true` when `window.innerWidth < 640`. Used by App, BillsTab, and AnalyticsTab.

### `App.tsx` — header
- Logo text hidden on mobile to free space for nav buttons
- Nav buttons collapse to **icon-only** (labels hidden); `title` attribute keeps accessibility
- Sign-out button collapses to icon-only on mobile
- Header padding `16px 24px` → `12px 16px` on mobile
- Main content padding `24px` → `16px / 12px` on mobile

### `BillsTab.tsx` — bill cards
- Bill row padding reduced, icon shrunk to 36 px
- **Type badge** hidden on mobile (visible in the expanded detail view)
- **Period range** (`period_start → period_end`) hidden on mobile
- Consumption (kWh / m³) hidden on mobile
- Amount font size 18 → 15 px on mobile
- **Line-items table** wrapped in `overflowX: auto` + `minWidth: 360` so it scrolls horizontally instead of overflowing

### `AnalyticsTab.tsx` — charts & tables
- `chartH(base)` helper scales all chart heights to 75% on mobile
- Two-column `grid2` layout forced to single column on mobile (`"1fr"`); gap reduced 20 → 12 px
- **Summary stats table** (section 8) wrapped in `overflowX: auto` + `minWidth: 520`
- Provider chart `YAxis` width 120 → 80 px on mobile; tick font 12 → 10 px

## Test plan
- [ ] iPhone SE (375 px) — header fits without overflow, nav is icon-only
- [ ] Upload tab — max-width 640 already constrains it; OK on mobile
- [ ] Bills tab — bill row is readable; tapping a row expands detail with scrollable line-items table
- [ ] Analytics tab — charts stack vertically; all tables scroll horizontally rather than overflow
- [ ] Desktop (1280 px) — no visual regression vs. before

https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG

---
_Generated by [Claude Code](https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG)_