### PR TITLE
feat: multi-file uploads (25 MB) + per-user data isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Backend env vars (see `backend/.env.example` for the full list):
 - `PARSER_BACKEND=claude` — Anthropic Claude API, requires `ANTHROPIC_API_KEY` (paid). Highest accuracy; use only if the free OpenRouter models aren't getting the job done.
 - `APP_PASSWORD` — optional shared-password login gate. Unset = no login required.
 - `AUTH_SECRET` — required when `APP_PASSWORD` is set. 64-char hex, generate with `python -c "import secrets; print(secrets.token_hex(32))"`.
-- `MAX_UPLOAD_BYTES` — hard cap on upload size in bytes (default 20 MB).
+- `MAX_UPLOAD_BYTES` — hard cap on upload size in bytes per file (default 25 MB). Multi-file uploads are supported; each file is bounded by this limit.
 - `DB_PATH`, `UPLOADS_DIR`, `LOG_LEVEL` — override storage paths and log verbosity.
 
 Frontend env var (see `frontend/.env.example`):

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Open **http://localhost:5173**. Uploads and the SQLite DB are persisted in a nam
 
 A free-tier cloud setup: **Vercel** for the frontend, **Render** for the backend.
 
-> ⚠️ The demo uses a **single shared password** — fine for a personal deployment but not a real multi-user product. Treat it as a personal demo, not a shared service. For a public-grade deployment, swap this for proper OAuth or Cloudflare Access.
+> ⚠️ The demo uses a **single shared password** — fine for a personal deployment but not a real multi-user product. Each successful login mints a fresh per-browser data space, so two people sharing the password get isolated bills (no cross-deletion), but anyone can still see their *own* uploads on any device they log in from. For a public-grade deployment, swap this for proper OAuth or Cloudflare Access.
 
 ### 1. Backend on Render
 
@@ -108,7 +108,7 @@ CORS_ALLOW_ORIGINS=https://bills.example.com,https://www.bills.example.com
 
 ### 4. Login
 
-Visiting the Vercel URL will show a password prompt. Enter the `APP_PASSWORD` you set on Render. The token is stored in `localStorage` and lasts 7 days (override with `TOKEN_TTL_SEC`). To rotate the password, change `APP_PASSWORD` on Render — existing tokens stay valid until they expire unless you also rotate `AUTH_SECRET` (which invalidates every token immediately).
+Visiting the Vercel URL will show a password prompt. Enter the `APP_PASSWORD` you set on Render. The token is stored in `localStorage` and lasts 7 days (override with `TOKEN_TTL_SEC`). Each successful login generates a fresh, isolated data space — uploaded bills are scoped to the logging-in browser and aren't visible to other people who log in with the same password. Logging out and back in starts a new (empty) space; the old bills stay in the database but are no longer reachable from that browser. To rotate the password, change `APP_PASSWORD` on Render — existing tokens stay valid until they expire unless you also rotate `AUTH_SECRET` (which invalidates every token immediately).
 
 For local development, leave `APP_PASSWORD` unset and the login screen is skipped entirely.
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -41,10 +41,10 @@ def _b64url_decode(data: str) -> bytes:
     return base64.urlsafe_b64decode(data + padding)
 
 
-def create_token(ttl_sec: int | None = None) -> str:
+def create_token(user_id: str, ttl_sec: int | None = None) -> str:
     if not AUTH_SECRET:
         raise AuthError("AUTH_SECRET is not configured")
-    payload = {"exp": int(time.time()) + (ttl_sec or TOKEN_TTL_SEC)}
+    payload = {"sub": user_id, "exp": int(time.time()) + (ttl_sec or TOKEN_TTL_SEC)}
     payload_b64 = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
     sig = hmac.new(AUTH_SECRET.encode(), payload_b64.encode(), hashlib.sha256).hexdigest()
     return f"{payload_b64}.{sig}"

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,7 +33,7 @@ UPLOADS_DIR = os.environ.get("UPLOADS_DIR", "uploads")
 os.makedirs(UPLOADS_DIR, exist_ok=True)
 
 # Hard cap on upload size — protects against memory exhaustion from huge files.
-MAX_UPLOAD_BYTES = int(os.environ.get("MAX_UPLOAD_BYTES", 20 * 1024 * 1024))  # 20 MB
+MAX_UPLOAD_BYTES = int(os.environ.get("MAX_UPLOAD_BYTES", 25 * 1024 * 1024))  # 25 MB
 
 # Allowed filename extensions (lowercased). The MIME check below is the
 # primary gate; this second check rejects mismatched / hostile filenames.

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 
 import aiosqlite
 import httpx
-from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
+from fastapi import Depends, FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
@@ -32,6 +32,21 @@ DB_PATH = os.environ.get("DB_PATH", "bills.db")
 UPLOADS_DIR = os.environ.get("UPLOADS_DIR", "uploads")
 os.makedirs(UPLOADS_DIR, exist_ok=True)
 
+# Connection-level busy timeout — SQLite serialises writes, so under
+# concurrent uploads from multiple browsers a writer can otherwise hit
+# "database is locked" almost immediately. 10 s is comfortably longer
+# than any single write transaction in this app.
+DB_BUSY_TIMEOUT_SEC = 10.0
+
+# user_id assigned to bills uploaded while auth is disabled (local dev),
+# and the migration target for legacy rows that predate user-scoping.
+_DEFAULT_USER_ID = "default"
+
+
+def _db():
+    """Open a SQLite connection with our shared busy-timeout."""
+    return aiosqlite.connect(DB_PATH, timeout=DB_BUSY_TIMEOUT_SEC)
+
 # Hard cap on upload size — protects against memory exhaustion from huge files.
 MAX_UPLOAD_BYTES = int(os.environ.get("MAX_UPLOAD_BYTES", 25 * 1024 * 1024))  # 25 MB
 
@@ -51,7 +66,12 @@ _EDITABLE_BILL_COLUMNS = frozenset({
 
 
 async def init_db() -> None:
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _db() as db:
+        # WAL mode lets readers and a single writer proceed concurrently
+        # instead of blocking each other — important when several browsers
+        # are uploading bills at the same time. Setting persists in the
+        # database header so this runs once per database.
+        await db.execute("PRAGMA journal_mode=WAL")
         await db.execute("""
             CREATE TABLE IF NOT EXISTS bills (
                 id TEXT PRIMARY KEY,
@@ -71,6 +91,22 @@ async def init_db() -> None:
                 notes TEXT
             )
         """)
+        # Migration: add user_id to existing databases that were created
+        # before per-user scoping. Backfilling to "default" keeps local-dev
+        # data visible (auth-disabled mode also uses "default"); in
+        # auth-enabled production these legacy rows become orphans, which
+        # is intentional — they were uploaded by no particular user.
+        async with db.execute("PRAGMA table_info(bills)") as c:
+            cols = {row[1] for row in await c.fetchall()}
+        if "user_id" not in cols:
+            await db.execute("ALTER TABLE bills ADD COLUMN user_id TEXT")
+            await db.execute(
+                "UPDATE bills SET user_id = ? WHERE user_id IS NULL",
+                (_DEFAULT_USER_ID,),
+            )
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS bills_user_id_idx ON bills(user_id)"
+        )
         await db.commit()
 
 
@@ -119,7 +155,10 @@ async def auth_middleware(request: Request, call_next):
     # custom headers (including Authorization) before sending them.
     if request.method == "OPTIONS":
         return await call_next(request)
+    # Auth disabled (local dev): everyone shares the "default" data space
+    # so existing bills stay visible and dev workflows don't change.
     if not auth_mod.auth_enabled():
+        request.state.user_id = _DEFAULT_USER_ID
         return await call_next(request)
     path = request.url.path
     if not path.startswith("/api/") or path in _AUTH_EXEMPT_PATHS:
@@ -128,10 +167,18 @@ async def auth_middleware(request: Request, call_next):
     if not header.lower().startswith("bearer "):
         return JSONResponse({"detail": "Missing bearer token"}, status_code=401)
     try:
-        auth_mod.verify_token(header[7:].strip())
+        payload = auth_mod.verify_token(header[7:].strip())
     except auth_mod.AuthError as e:
         return JSONResponse({"detail": f"Invalid token: {e}"}, status_code=401)
+    # Tokens issued before per-user scoping have no `sub` — map them to
+    # the legacy "default" space so they keep working for one TTL window.
+    request.state.user_id = payload.get("sub") or _DEFAULT_USER_ID
     return await call_next(request)
+
+
+def get_user_id(request: Request) -> str:
+    """Resolve the caller's user_id, set by auth_middleware."""
+    return getattr(request.state, "user_id", _DEFAULT_USER_ID)
 
 
 if auth_mod.auth_enabled() and not auth_mod.AUTH_SECRET:
@@ -159,7 +206,10 @@ async def auth_login(body: LoginRequest):
         return {"token": "disabled", "auth_required": False}
     if not auth_mod.verify_password(body.password):
         raise HTTPException(401, "Invalid password")
-    return {"token": auth_mod.create_token(), "auth_required": True}
+    # Each successful login mints a fresh user_id, so two browsers sharing
+    # the same demo password get separate, isolated data spaces.
+    user_id = uuid.uuid4().hex
+    return {"token": auth_mod.create_token(user_id), "auth_required": True}
 
 
 class BillUpdate(BaseModel):
@@ -285,6 +335,7 @@ async def upload_bill(
     file: UploadFile = File(...),
     parser: str | None = Form(None),
     model: str | None = Form(None),
+    user_id: str = Depends(get_user_id),
 ):
     if file.content_type not in _ALLOWED_MIME:
         raise HTTPException(400, "Unsupported file type. Upload an image or PDF.")
@@ -349,13 +400,15 @@ async def upload_bill(
     replaced = False
     replaced_id: str | None = None
 
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _db() as db:
+        # All dedupe lookups are scoped to the caller's user_id so one
+        # user's upload can never overwrite another user's bill.
         # 1st priority: same filename → same physical file uploaded again
         existing_row = None
         async with db.execute(
-            "SELECT id, filename FROM bills WHERE filename = ? "
+            "SELECT id, filename FROM bills WHERE filename = ? AND user_id = ? "
             "ORDER BY upload_date DESC LIMIT 1",
-            (file.filename,),
+            (file.filename, user_id),
         ) as c:
             existing_row = await c.fetchone()
 
@@ -363,9 +416,9 @@ async def upload_bill(
         if not existing_row and provider and period_start:
             async with db.execute(
                 "SELECT id, filename FROM bills "
-                "WHERE LOWER(TRIM(provider)) = LOWER(TRIM(?)) AND period_start = ? "
+                "WHERE LOWER(TRIM(provider)) = LOWER(TRIM(?)) AND period_start = ? AND user_id = ? "
                 "ORDER BY upload_date DESC LIMIT 1",
-                (provider, period_start),
+                (provider, period_start, user_id),
             ) as c:
                 existing_row = await c.fetchone()
 
@@ -373,9 +426,9 @@ async def upload_bill(
         if not existing_row and provider and account_number:
             async with db.execute(
                 "SELECT id, filename FROM bills "
-                "WHERE LOWER(TRIM(provider)) = LOWER(TRIM(?)) AND account_number = ? "
+                "WHERE LOWER(TRIM(provider)) = LOWER(TRIM(?)) AND account_number = ? AND user_id = ? "
                 "ORDER BY upload_date DESC LIMIT 1",
-                (provider, account_number),
+                (provider, account_number, user_id),
             ) as c:
                 existing_row = await c.fetchone()
 
@@ -409,7 +462,7 @@ async def upload_bill(
                     utility_type = ?, amount_eur = ?, consumption_kwh = ?,
                     consumption_m3 = ?, period_start = ?, period_end = ?,
                     account_number = ?, address = ?, raw_json = ?
-                WHERE id = ?
+                WHERE id = ? AND user_id = ?
             """, (
                 file.filename, now,
                 parsed.get("bill_date"),
@@ -424,13 +477,14 @@ async def upload_bill(
                 parsed.get("address"),
                 json.dumps(parsed),
                 replaced_id,
+                user_id,
             ))
         else:
             await db.execute("""
                 INSERT INTO bills (id, filename, upload_date, bill_date, provider, utility_type,
                     amount_eur, consumption_kwh, consumption_m3, period_start, period_end,
-                    account_number, address, raw_json)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    account_number, address, raw_json, user_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 bill_id, file.filename, now,
                 parsed.get("bill_date"),
@@ -444,6 +498,7 @@ async def upload_bill(
                 parsed.get("account_number"),
                 parsed.get("address"),
                 json.dumps(parsed),
+                user_id,
             ))
         await db.commit()
 
@@ -451,21 +506,26 @@ async def upload_bill(
 
 
 @app.get("/api/bills")
-async def list_bills():
-    async with aiosqlite.connect(DB_PATH) as db:
+async def list_bills(user_id: str = Depends(get_user_id)):
+    async with _db() as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
-            "SELECT * FROM bills ORDER BY bill_date DESC, upload_date DESC"
+            "SELECT * FROM bills WHERE user_id = ? "
+            "ORDER BY bill_date DESC, upload_date DESC",
+            (user_id,),
         ) as cursor:
             rows = await cursor.fetchall()
     return [dict(r) for r in rows]
 
 
 @app.get("/api/bills/{bill_id}")
-async def get_bill(bill_id: str):
-    async with aiosqlite.connect(DB_PATH) as db:
+async def get_bill(bill_id: str, user_id: str = Depends(get_user_id)):
+    async with _db() as db:
         db.row_factory = aiosqlite.Row
-        async with db.execute("SELECT * FROM bills WHERE id = ?", (bill_id,)) as cursor:
+        async with db.execute(
+            "SELECT * FROM bills WHERE id = ? AND user_id = ?",
+            (bill_id, user_id),
+        ) as cursor:
             row = await cursor.fetchone()
     if not row:
         raise HTTPException(404, "Bill not found")
@@ -473,7 +533,11 @@ async def get_bill(bill_id: str):
 
 
 @app.put("/api/bills/{bill_id}")
-async def update_bill(bill_id: str, update: BillUpdate):
+async def update_bill(
+    bill_id: str,
+    update: BillUpdate,
+    user_id: str = Depends(get_user_id),
+):
     # Filter to editable columns only. Even though BillUpdate pins the shape,
     # the explicit allowlist prevents future field additions from silently
     # becoming writable at the HTTP layer.
@@ -484,17 +548,23 @@ async def update_bill(bill_id: str, update: BillUpdate):
     if not fields:
         raise HTTPException(400, "No fields to update")
     set_clause = ", ".join(f"{k} = ?" for k in fields)
-    values = list(fields.values()) + [bill_id]
-    async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(f"UPDATE bills SET {set_clause} WHERE id = ?", values)
+    values = list(fields.values()) + [bill_id, user_id]
+    async with _db() as db:
+        await db.execute(
+            f"UPDATE bills SET {set_clause} WHERE id = ? AND user_id = ?",
+            values,
+        )
         await db.commit()
     return {"status": "updated"}
 
 
 @app.delete("/api/bills/{bill_id}")
-async def delete_bill(bill_id: str):
-    async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute("DELETE FROM bills WHERE id = ?", (bill_id,))
+async def delete_bill(bill_id: str, user_id: str = Depends(get_user_id)):
+    async with _db() as db:
+        await db.execute(
+            "DELETE FROM bills WHERE id = ? AND user_id = ?",
+            (bill_id, user_id),
+        )
         await db.commit()
     return {"status": "deleted"}
 
@@ -581,8 +651,8 @@ async def _build_openrouter_chain(user_model: str, max_models: int = 4) -> list[
 
 
 @app.get("/api/analytics/summary")
-async def analytics_summary():
-    async with aiosqlite.connect(DB_PATH) as db:
+async def analytics_summary(user_id: str = Depends(get_user_id)):
+    async with _db() as db:
         db.row_factory = aiosqlite.Row
 
         # Fetch every bill so we can split korteriühistu bills into their
@@ -593,8 +663,8 @@ async def analytics_summary():
             SELECT id, utility_type, amount_eur, consumption_kwh, consumption_m3,
                    period_start, bill_date, upload_date, raw_json
             FROM bills
-            WHERE amount_eur IS NOT NULL
-        """) as c:
+            WHERE amount_eur IS NOT NULL AND user_id = ?
+        """, (user_id,)) as c:
             all_bills = [dict(r) for r in await c.fetchall()]
 
         async with db.execute("""
@@ -604,10 +674,10 @@ async def analytics_summary():
                 SUM(amount_eur) as total_eur,
                 AVG(amount_eur) as avg_eur
             FROM bills
-            WHERE amount_eur IS NOT NULL AND provider IS NOT NULL
+            WHERE amount_eur IS NOT NULL AND provider IS NOT NULL AND user_id = ?
             GROUP BY provider
             ORDER BY total_eur DESC
-        """) as c:
+        """, (user_id,)) as c:
             by_provider = [dict(r) for r in await c.fetchall()]
 
         async with db.execute("""
@@ -615,10 +685,10 @@ async def analytics_summary():
                 strftime('%Y-%m', COALESCE(period_start, bill_date, upload_date)) as month,
                 SUM(amount_eur) as total_eur
             FROM bills
-            WHERE amount_eur IS NOT NULL
+            WHERE amount_eur IS NOT NULL AND user_id = ?
             GROUP BY month
             ORDER BY month
-        """) as c:
+        """, (user_id,)) as c:
             monthly_total = [dict(r) for r in await c.fetchall()]
 
     # ────────────────────────────────────────────────────────────────────
@@ -794,10 +864,12 @@ async def analytics_summary():
     _suffix_et = _re_li.compile(r"\s+[Aa]lg[:\s].*$")
 
     line_item_trends: list[dict] = []
-    async with aiosqlite.connect(DB_PATH) as db:
+    async with _db() as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
-            "SELECT period_start, bill_date, upload_date, raw_json FROM bills WHERE raw_json IS NOT NULL"
+            "SELECT period_start, bill_date, upload_date, raw_json FROM bills "
+            "WHERE raw_json IS NOT NULL AND user_id = ?",
+            (user_id,),
         ) as c:
             bill_rows = await c.fetchall()
 

--- a/backend/test_auth.py
+++ b/backend/test_auth.py
@@ -47,14 +47,24 @@ def test_verify_password_constant_time(monkeypatch):
 
 def test_token_roundtrip(monkeypatch):
     auth = _reload_auth(monkeypatch, password="hunter2", secret="x" * 64)
-    tok = auth.create_token()
+    tok = auth.create_token("user-abc")
     payload = auth.verify_token(tok)
     assert payload["exp"] > int(time.time())
+    assert payload["sub"] == "user-abc"
+
+
+def test_token_carries_distinct_user_ids(monkeypatch):
+    auth = _reload_auth(monkeypatch, password="hunter2", secret="x" * 64)
+    tok_a = auth.create_token("alice")
+    tok_b = auth.create_token("bob")
+    assert auth.verify_token(tok_a)["sub"] == "alice"
+    assert auth.verify_token(tok_b)["sub"] == "bob"
+    assert tok_a != tok_b
 
 
 def test_token_tampered_signature_rejected(monkeypatch):
     auth = _reload_auth(monkeypatch, password="hunter2", secret="x" * 64)
-    tok = auth.create_token()
+    tok = auth.create_token("user-abc")
     body, sig = tok.rsplit(".", 1)
     tampered = f"{body}.{'0' * len(sig)}"
     with pytest.raises(auth.AuthError):
@@ -63,7 +73,7 @@ def test_token_tampered_signature_rejected(monkeypatch):
 
 def test_token_tampered_payload_rejected(monkeypatch):
     auth = _reload_auth(monkeypatch, password="hunter2", secret="x" * 64)
-    tok = auth.create_token()
+    tok = auth.create_token("user-abc")
     body, sig = tok.rsplit(".", 1)
     # Flip the last character of the payload — signature should no longer match.
     flipped_char = "A" if body[-1] != "A" else "B"
@@ -74,7 +84,7 @@ def test_token_tampered_payload_rejected(monkeypatch):
 
 def test_token_expired(monkeypatch):
     auth = _reload_auth(monkeypatch, password="hunter2", secret="x" * 64)
-    tok = auth.create_token(ttl_sec=-1)
+    tok = auth.create_token("user-abc", ttl_sec=-1)
     with pytest.raises(auth.AuthError, match="expired"):
         auth.verify_token(tok)
 
@@ -88,12 +98,12 @@ def test_token_malformed(monkeypatch):
 def test_secret_required_for_create(monkeypatch):
     auth = _reload_auth(monkeypatch, password="hunter2")  # no secret
     with pytest.raises(auth.AuthError):
-        auth.create_token()
+        auth.create_token("user-abc")
 
 
 def test_different_secrets_produce_incompatible_tokens(monkeypatch):
     auth = _reload_auth(monkeypatch, password="hunter2", secret="secret-a" * 8)
-    tok = auth.create_token()
+    tok = auth.create_token("user-abc")
     auth2 = _reload_auth(monkeypatch, password="hunter2", secret="secret-b" * 8)
     with pytest.raises(auth2.AuthError):
         auth2.verify_token(tok)

--- a/frontend/src/components/UploadTab.tsx
+++ b/frontend/src/components/UploadTab.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { api } from "../api";
-import { Upload, CheckCircle, AlertCircle, Loader2, RefreshCw } from "lucide-react";
+import { Upload, CheckCircle, AlertCircle, Loader2, RefreshCw, FileText, X } from "lucide-react";
 
 const UTILITY_ICONS: Record<string, string> = {
   electricity: "⚡",
@@ -12,27 +12,39 @@ const UTILITY_ICONS: Record<string, string> = {
   other: "📄",
 };
 
+const MAX_FILE_BYTES = 25 * 1024 * 1024; // 25 MB — must match backend MAX_UPLOAD_BYTES
+const MAX_FILE_MB = MAX_FILE_BYTES / (1024 * 1024);
+
 interface UploadTabProps {
   onSuccess: () => void;
 }
 
-type Status = "idle" | "uploading" | "success" | "replaced" | "error";
+type ItemStatus = "pending" | "uploading" | "success" | "replaced" | "error" | "low_quality" | "too_large";
 type ParserMode = "tesseract" | "openrouter";
 
-// Fallback list if the backend can't fetch the live list from OpenRouter.
-// The live list comes from GET /api/openrouter-models and is fetched on
-// mount — OpenRouter changes their free tier often enough that a hardcoded
-// list goes stale within weeks.
+interface QueueItem {
+  id: string;
+  file: File;
+  status: ItemStatus;
+  errorMsg?: string;
+  parsed?: Record<string, unknown>;
+}
+
 const FALLBACK_MODELS = [
   { id: "google/gemini-2.0-flash-exp:free", label: "Gemini 2.0 Flash" },
   { id: "__custom__", label: "Custom model ID…" },
 ];
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 export default function UploadTab({ onSuccess }: UploadTabProps) {
   const [dragging, setDragging] = useState(false);
-  const [status, setStatus] = useState<Status>("idle");
-  const [parsed, setParsed] = useState<Record<string, unknown> | null>(null);
-  const [errorMsg, setErrorMsg] = useState("");
+  const [queue, setQueue] = useState<QueueItem[]>([]);
+  const [running, setRunning] = useState(false);
   const [parserMode, setParserMode] = useState<ParserMode>("openrouter");
   const [availableModels, setAvailableModels] = useState(FALLBACK_MODELS);
   const [selectedModel, setSelectedModel] = useState(FALLBACK_MODELS[0].id);
@@ -51,7 +63,7 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
         if (live.length > 0) setSelectedModel(live[0].id);
       })
       .catch(() => {
-        // Backend unreachable or failed — fallback list is already in state.
+        // Backend unreachable — keep fallback list.
       })
       .finally(() => {
         if (!cancelled) setModelsLoading(false);
@@ -59,40 +71,92 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
     return () => { cancelled = true; };
   }, []);
 
-  const handleFile = useCallback(async (file: File) => {
-    setStatus("uploading");
-    setParsed(null);
-    setErrorMsg("");
-    try {
-      const effectiveModel =
-        parserMode === "openrouter"
-          ? (selectedModel === "__custom__" ? customModel.trim() : selectedModel)
-          : undefined;
-      const res = await api.uploadBill(file, parserMode, effectiveModel || undefined);
-      setParsed(res.data.parsed);
-      setStatus(res.data.replaced ? "replaced" : "success");
-      // If parsing failed, keep the user on this tab so they can read the
-      // error and pick a different model. They can navigate to Bills manually.
-      if (!res.data.parsed?._low_quality) {
-        setTimeout(onSuccess, 2000);
+  const updateItem = useCallback((id: string, patch: Partial<QueueItem>) => {
+    setQueue(q => q.map(it => (it.id === id ? { ...it, ...patch } : it)));
+  }, []);
+
+  const processQueue = useCallback(async (items: QueueItem[]) => {
+    setRunning(true);
+    const effectiveModel =
+      parserMode === "openrouter"
+        ? (selectedModel === "__custom__" ? customModel.trim() : selectedModel)
+        : undefined;
+
+    let successCount = 0;
+    let problemCount = 0;
+    for (const item of items) {
+      if (item.status !== "pending") continue;
+      updateItem(item.id, { status: "uploading" });
+      try {
+        const res = await api.uploadBill(item.file, parserMode, effectiveModel || undefined);
+        const parsed = res.data.parsed;
+        const lowQuality = Boolean(parsed?._low_quality);
+        if (lowQuality) {
+          problemCount += 1;
+          updateItem(item.id, { status: "low_quality", parsed });
+        } else {
+          successCount += 1;
+          updateItem(item.id, { status: res.data.replaced ? "replaced" : "success", parsed });
+        }
+      } catch (e: unknown) {
+        problemCount += 1;
+        const msg = e instanceof Error ? e.message : "Upload failed";
+        updateItem(item.id, { status: "error", errorMsg: msg });
       }
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "Upload failed";
-      setErrorMsg(msg);
-      setStatus("error");
     }
-  }, [onSuccess, parserMode, selectedModel, customModel]);
+    setRunning(false);
+    // Auto-navigate only if everything went smoothly (no errors, no low quality).
+    if (successCount > 0 && problemCount === 0) {
+      setTimeout(onSuccess, 2000);
+    }
+  }, [parserMode, selectedModel, customModel, updateItem, onSuccess]);
+
+  const addFiles = useCallback((files: File[]) => {
+    if (files.length === 0) return;
+    const items: QueueItem[] = files.map(file => {
+      const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      if (file.size > MAX_FILE_BYTES) {
+        return {
+          id,
+          file,
+          status: "too_large",
+          errorMsg: `File too large (${formatBytes(file.size)}). Maximum size is ${MAX_FILE_MB} MB per file.`,
+        };
+      }
+      return { id, file, status: "pending" };
+    });
+    setQueue(items);
+    const toUpload = items.filter(it => it.status === "pending");
+    if (toUpload.length > 0) {
+      // Defer to next tick so React commits the queue first — otherwise the
+      // first file's "uploading" status overwrites the initial render.
+      setTimeout(() => processQueue(toUpload), 0);
+    }
+  }, [processQueue]);
 
   const onDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     setDragging(false);
-    const file = e.dataTransfer.files[0];
-    if (file) handleFile(file);
-  }, [handleFile]);
+    if (running) return;
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length > 0) addFiles(files);
+  }, [addFiles, running]);
 
   const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) handleFile(file);
+    const files = Array.from(e.target.files ?? []);
+    if (files.length > 0) addFiles(files);
+    // Reset so re-selecting the same file fires onChange again.
+    e.target.value = "";
+  };
+
+  const removeItem = (id: string) => {
+    if (running) return;
+    setQueue(q => q.filter(it => it.id !== id));
+  };
+
+  const clearAll = () => {
+    if (running) return;
+    setQueue([]);
   };
 
   const cardStyle = {
@@ -102,13 +166,19 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
     padding: 24,
   };
 
-  const isSuccess = status === "success" || status === "replaced";
+  const allDone = queue.length > 0 && queue.every(it => it.status !== "pending" && it.status !== "uploading");
+  const singleSuccess = queue.length === 1 && (queue[0].status === "success" || queue[0].status === "replaced" || queue[0].status === "low_quality");
+  const detailItem = singleSuccess ? queue[0] : null;
+  const parsed = detailItem?.parsed;
+
+  const successCount = queue.filter(it => it.status === "success" || it.status === "replaced").length;
+  const problemCount = queue.filter(it => it.status === "error" || it.status === "low_quality" || it.status === "too_large").length;
 
   return (
     <div style={{ maxWidth: 640, margin: "0 auto" }}>
       <h2 style={{ color: "white", marginBottom: 8, fontSize: 22 }}>Upload Invoice / Bill</h2>
       <p style={{ color: "#9ca3af", marginBottom: 16, fontSize: 14 }}>
-        Choose how to extract data from your invoice, then drop or select the file.
+        Drop one or more files (up to {MAX_FILE_MB} MB each) to extract data.
       </p>
 
       {/* Parser selector */}
@@ -124,14 +194,16 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
             <button
               key={id}
               onClick={() => setParserMode(id)}
+              disabled={running}
               style={{
                 flex: 1,
                 background: parserMode === id ? "#1e2640" : "#252838",
                 border: `1.5px solid ${parserMode === id ? "#2563eb" : "#374151"}`,
                 borderRadius: 8,
                 padding: "10px 12px",
-                cursor: "pointer",
+                cursor: running ? "not-allowed" : "pointer",
                 textAlign: "left",
+                opacity: running ? 0.6 : 1,
               }}
             >
               <div style={{ color: parserMode === id ? "#93c5fd" : "#e5e7eb", fontSize: 13, fontWeight: 600 }}>{label}</div>
@@ -148,7 +220,7 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
             <select
               value={selectedModel}
               onChange={(e) => setSelectedModel(e.target.value)}
-              disabled={modelsLoading}
+              disabled={modelsLoading || running}
               style={{
                 width: "100%",
                 background: "#252838",
@@ -157,8 +229,8 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
                 color: "#e5e7eb",
                 padding: "7px 10px",
                 fontSize: 13,
-                cursor: modelsLoading ? "wait" : "pointer",
-                opacity: modelsLoading ? 0.6 : 1,
+                cursor: modelsLoading || running ? "not-allowed" : "pointer",
+                opacity: modelsLoading || running ? 0.6 : 1,
               }}
             >
               {availableModels.map(m => (
@@ -171,6 +243,7 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
                 value={customModel}
                 onChange={(e) => setCustomModel(e.target.value)}
                 placeholder="e.g. mistralai/pixtral-12b:free"
+                disabled={running}
                 style={{
                   width: "100%",
                   background: "#252838",
@@ -194,77 +267,91 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
         )}
       </div>
 
-      <div
-        onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
-        onDragLeave={() => setDragging(false)}
-        onDrop={onDrop}
-        style={{
-          ...cardStyle,
-          border: `2px dashed ${dragging ? "#2563eb" : "#374151"}`,
-          background: dragging ? "#1e2640" : "#1a1d27",
-          textAlign: "center",
-          padding: "48px 24px",
-          cursor: "pointer",
-          transition: "all 0.15s",
-        }}
-        onClick={() => fileInputRef.current?.click()}
-      >
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*,.pdf"
-          style={{ display: "none" }}
-          onChange={onFileChange}
-        />
-        {status === "uploading" ? (
-          <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-            <Loader2 size={40} color="#2563eb" style={{ animation: "spin 1s linear infinite" }} />
-            <p style={{ color: "#9ca3af", margin: 0 }}>
-              {parserMode === "openrouter" ? "Sending to AI model…" : "Running OCR & extracting line items…"}
-            </p>
-          </div>
-        ) : status === "replaced" ? (
-          <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-            <RefreshCw size={40} color="#f59e0b" />
-            <p style={{ color: "#f59e0b", margin: 0, fontWeight: 600 }}>Existing bill replaced</p>
-            <p style={{ color: "#9ca3af", margin: 0, fontSize: 13 }}>Duplicate detected — previous entry updated</p>
-          </div>
-        ) : status === "success" ? (
-          <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-            {parsed?._low_quality ? (
-              <>
-                <AlertCircle size={40} color="#f59e0b" />
-                <p style={{ color: "#f59e0b", margin: 0, fontWeight: 600 }}>File saved, but data couldn't be extracted</p>
-                <p style={{ color: "#9ca3af", margin: 0, fontSize: 13 }}>See details below — try a different model or upload again</p>
-              </>
-            ) : (
-              <>
-                <CheckCircle size={40} color="#22c55e" />
-                <p style={{ color: "#22c55e", margin: 0, fontWeight: 600 }}>Bill uploaded successfully!</p>
-                <p style={{ color: "#9ca3af", margin: 0, fontSize: 13 }}>Redirecting to bills list…</p>
-              </>
-            )}
-          </div>
-        ) : status === "error" ? (
-          <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-            <AlertCircle size={40} color="#ef4444" />
-            <p style={{ color: "#ef4444", margin: 0 }}>{errorMsg}</p>
-            <p style={{ color: "#9ca3af", margin: 0, fontSize: 13 }}>Click to try again</p>
-          </div>
-        ) : (
+      {/* Drop zone — hidden once the queue has items so the queue takes over the visual focus. */}
+      {queue.length === 0 && (
+        <div
+          onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+          onDragLeave={() => setDragging(false)}
+          onDrop={onDrop}
+          style={{
+            ...cardStyle,
+            border: `2px dashed ${dragging ? "#2563eb" : "#374151"}`,
+            background: dragging ? "#1e2640" : "#1a1d27",
+            textAlign: "center",
+            padding: "48px 24px",
+            cursor: "pointer",
+            transition: "all 0.15s",
+          }}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*,.pdf"
+            multiple
+            style={{ display: "none" }}
+            onChange={onFileChange}
+          />
           <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
             <div style={{ width: 64, height: 64, background: "#1e2640", borderRadius: "50%", display: "flex", alignItems: "center", justifyContent: "center" }}>
               <Upload size={28} color="#2563eb" />
             </div>
             <div>
-              <p style={{ color: "white", margin: 0, fontWeight: 600 }}>Drop your bill here</p>
-              <p style={{ color: "#9ca3af", margin: "4px 0 0", fontSize: 13 }}>or click to browse — JPG, PNG, PDF supported</p>
+              <p style={{ color: "white", margin: 0, fontWeight: 600 }}>Drop your bills here</p>
+              <p style={{ color: "#9ca3af", margin: "4px 0 0", fontSize: 13 }}>
+                or click to browse — multiple files allowed, up to {MAX_FILE_MB} MB each
+              </p>
             </div>
           </div>
-        )}
-      </div>
+        </div>
+      )}
 
-      {isSuccess && parsed && Boolean(parsed._low_quality) && (
+      {/* Upload queue */}
+      {queue.length > 0 && (
+        <div style={{ ...cardStyle, padding: 16 }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+            <div style={{ color: "white", fontSize: 14, fontWeight: 600 }}>
+              {running ? `Processing ${queue.length} file${queue.length === 1 ? "" : "s"}…` : `${queue.length} file${queue.length === 1 ? "" : "s"}`}
+              {!running && allDone && (
+                <span style={{ color: "#6b7280", fontWeight: 400, marginLeft: 8 }}>
+                  · {successCount} succeeded{problemCount > 0 ? `, ${problemCount} with issues` : ""}
+                </span>
+              )}
+            </div>
+            {allDone && !running && (
+              <button
+                onClick={clearAll}
+                style={{
+                  background: "transparent",
+                  border: "1px solid #374151",
+                  borderRadius: 6,
+                  color: "#9ca3af",
+                  padding: "5px 10px",
+                  fontSize: 12,
+                  cursor: "pointer",
+                }}
+              >
+                Upload more
+              </button>
+            )}
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {queue.map(item => (
+              <QueueRow key={item.id} item={item} onRemove={removeItem} disabled={running} />
+            ))}
+          </div>
+          {allDone && successCount > 0 && (
+            <div style={{ marginTop: 12, fontSize: 12, color: "#9ca3af" }}>
+              {problemCount === 0
+                ? "Redirecting to bills list…"
+                : <>Some files had issues — you can fix them and try again, or <button onClick={onSuccess} style={{ background: "transparent", border: "none", color: "#93c5fd", cursor: "pointer", padding: 0, fontSize: 12, textDecoration: "underline" }}>view bills</button>.</>}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Detail panel — only when exactly one file was processed. */}
+      {detailItem && parsed && Boolean(parsed._low_quality) && (
         <div style={{
           ...cardStyle,
           marginTop: 24,
@@ -304,7 +391,7 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
         </div>
       )}
 
-      {isSuccess && parsed && Array.isArray(parsed._models_tried) && parsed._models_tried.length > 0 && parsed._model_used ? (
+      {detailItem && parsed && Array.isArray(parsed._models_tried) && parsed._models_tried.length > 0 && parsed._model_used ? (
         <div style={{
           ...cardStyle,
           marginTop: 16,
@@ -321,7 +408,7 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
         </div>
       ) : null}
 
-      {isSuccess && parsed && (
+      {detailItem && parsed && (
         <>
           <div style={{ ...cardStyle, marginTop: 24 }}>
             <h3 style={{ color: "white", margin: "0 0 16px", fontSize: 16 }}>
@@ -437,6 +524,90 @@ export default function UploadTab({ onSuccess }: UploadTabProps) {
       </div>
 
       <style>{`@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+}
+
+interface QueueRowProps {
+  item: QueueItem;
+  onRemove: (id: string) => void;
+  disabled: boolean;
+}
+
+function QueueRow({ item, onRemove, disabled }: QueueRowProps) {
+  const { status, file, errorMsg } = item;
+  const StatusIcon = (() => {
+    switch (status) {
+      case "uploading": return <Loader2 size={16} color="#2563eb" style={{ animation: "spin 1s linear infinite" }} />;
+      case "success": return <CheckCircle size={16} color="#22c55e" />;
+      case "replaced": return <RefreshCw size={16} color="#f59e0b" />;
+      case "low_quality": return <AlertCircle size={16} color="#f59e0b" />;
+      case "error":
+      case "too_large": return <AlertCircle size={16} color="#ef4444" />;
+      default: return <FileText size={16} color="#6b7280" />;
+    }
+  })();
+  const statusLabel = (() => {
+    switch (status) {
+      case "pending": return "Queued";
+      case "uploading": return "Uploading…";
+      case "success": return "Uploaded";
+      case "replaced": return "Replaced existing bill";
+      case "low_quality": return "Saved — extraction failed";
+      case "error": return errorMsg || "Upload failed";
+      case "too_large": return errorMsg || `File too large — max ${MAX_FILE_MB} MB`;
+    }
+  })();
+  const statusColor = (() => {
+    switch (status) {
+      case "success": return "#22c55e";
+      case "replaced":
+      case "low_quality": return "#f59e0b";
+      case "error":
+      case "too_large": return "#ef4444";
+      case "uploading": return "#93c5fd";
+      default: return "#9ca3af";
+    }
+  })();
+  const canRemove = !disabled && status !== "uploading";
+  return (
+    <div style={{
+      display: "flex",
+      alignItems: "center",
+      gap: 10,
+      padding: "8px 10px",
+      background: "#252838",
+      borderRadius: 8,
+      border: status === "error" || status === "too_large" ? "1px solid #ef4444" : "1px solid transparent",
+    }}>
+      <div style={{ flexShrink: 0 }}>{StatusIcon}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ color: "#e5e7eb", fontSize: 13, fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {file.name}
+        </div>
+        <div style={{ color: statusColor, fontSize: 11, marginTop: 1 }}>
+          {formatBytes(file.size)} · {statusLabel}
+        </div>
+      </div>
+      {canRemove && (
+        <button
+          onClick={() => onRemove(item.id)}
+          title="Remove"
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "#6b7280",
+            cursor: "pointer",
+            padding: 4,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+          }}
+        >
+          <X size={14} />
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Two related fixes for multi-user demo deployments.

## 1. Multi-file uploads (25 MB per file)

- **Backend**: `MAX_UPLOAD_BYTES` default 20 MB → 25 MB.
- **Frontend `UploadTab`** refactored from single-file to a queue:
  - Drop or pick multiple PDFs/images at once.
  - 25 MB cap validated client-side per file with a clear error.
  - Files upload sequentially through the existing endpoint to stay under OpenRouter rate limits.
  - Each row shows live status — queued, uploading, succeeded, replaced, saved-but-low-quality, error, too-large.
  - Auto-redirect to Bills only when every file succeeded; otherwise the queue stays so the user can fix issues.
  - Single-file uploads still render the rich detail panel.

## 2. Per-user data isolation + concurrent-write reliability

When several people logged in with the shared demo password, the upload dedupe-and-replace logic could silently overwrite another person's bill if it matched on filename, on `provider + period_start`, or on `provider + account_number`. From the original uploader's view the bill simply vanished.

- **Auth**: tokens now carry a `sub` claim with a fresh `uuid4` user_id minted per successful login. Each browser that logs in with the demo password gets an independent bill collection. Legacy tokens (no `sub`) degrade to the `"default"` data space for one TTL window then reissue cleanly on next login.
- **DB schema**: `bills` gains a `user_id` column with index. Existing rows migrate to `"default"` — auth-disabled local-dev keeps seeing its existing data; in auth-enabled production those rows become orphans (intentional — they had no real owner).
- **All bill SQL** — list, get, update, delete, upload dedupe, analytics summary, line-item trends — is now scoped by user_id, so cross-user reads/writes are impossible.
- **SQLite reliability**: WAL journal mode enabled at init plus a 10 s `busy_timeout` on every connection, so concurrent uploads from several browsers no longer race into `"database is locked"` errors.

## Test plan

- [ ] Single PDF upload still works, redirects to Bills, detail panel renders
- [ ] Multi-file: drop 3 PDFs → all queue, upload sequentially, redirect on full success
- [ ] Oversize file (>25 MB) → red row "File too large… Maximum size is 25 MB per file." and not sent to backend
- [ ] Two browsers, both log in with the same `APP_PASSWORD` → each only sees its own uploads
- [ ] Browser A uploads bill X; Browser B uploads same bill X → both keep their own copy (no replacement across users)
- [ ] Logout + login in same browser → fresh empty data space; previous bills are not visible (and remain in DB under the old user_id)
- [ ] Auth-disabled (local dev): all existing bills still visible after migration
- [ ] Concurrent uploads from two browsers do not produce 500 / "database is locked"
- [ ] `pytest test_auth.py` is green (token roundtrip carries `sub`)

https://claude.ai/code/session_013jQJnWABU5k4hFZXwR97HG