### PR TITLE
fix(upload): don't merge bills from different periods on same account

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,13 @@ jobs:
         run: ruff check .
 
       - name: Pytest
+        env:
+          # `main.py` raises at import time without AUTH_SECRET, and the
+          # auth helpers expect a Google client id to be configured.
+          # These are throwaway values just to satisfy the import-time
+          # checks in tests — no real auth happens.
+          AUTH_SECRET: ci-testing-secret-not-used-for-real-auth-0123456789abcdef
+          GOOGLE_CLIENT_ID: ci-test-client-id
         run: pytest -v
 
   frontend:

--- a/backend/db.py
+++ b/backend/db.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Any, Iterable
+from typing import Any
 
 import aiosqlite
 
@@ -95,7 +96,7 @@ class Cursor:
 
 
 class ExecuteOperation:
-    def __init__(self, conn: "BaseConnection", sql: str, params: tuple[Any, ...]):
+    def __init__(self, conn: BaseConnection, sql: str, params: tuple[Any, ...]):
         self.conn = conn
         self.sql = sql
         self.params = params

--- a/backend/google_auth.py
+++ b/backend/google_auth.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
-
 GOOGLE_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID", "")
 ALLOWED_EMAILS = frozenset(
     e.strip().lower()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
-import base64
 import asyncio
+import base64
 import json
 import logging
 import os

--- a/backend/main.py
+++ b/backend/main.py
@@ -705,11 +705,24 @@ async def upload_bill(
             ) as c:
                 existing_row = await c.fetchone()
 
-        # 3rd priority: same provider (case-insensitive) + same account number
-        if not existing_row and provider and account_number:
+        # 3rd priority: same provider (case-insensitive) + same account number,
+        # but ONLY as a fallback when the new upload has no period_start to
+        # match on. Otherwise distinct billing periods (Jan vs Feb on the
+        # same account) would be collapsed into one row, silently overwriting
+        # a previous month's bill — see the bug fix that restored this
+        # `elif`-style guard.
+        if (
+            not existing_row
+            and provider
+            and account_number
+            and not period_start
+        ):
             async with db.execute(
                 "SELECT id, filename FROM bills "
-                "WHERE LOWER(TRIM(provider)) = LOWER(TRIM(?)) AND account_number = ? AND user_id = ? "
+                "WHERE LOWER(TRIM(provider)) = LOWER(TRIM(?)) "
+                "AND account_number = ? "
+                "AND period_start IS NULL "
+                "AND user_id = ? "
                 "ORDER BY upload_date DESC LIMIT 1",
                 (provider, account_number, user_id),
             ) as c:

--- a/backend/parser.py
+++ b/backend/parser.py
@@ -13,9 +13,9 @@ gracefully for other Estonian utility bills.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
 import os
 import re
+from dataclasses import dataclass
 
 import pytesseract
 from PIL import Image

--- a/backend/parser_openai_compat.py
+++ b/backend/parser_openai_compat.py
@@ -16,7 +16,7 @@ import json
 import logging
 import os
 import time
-from typing import Mapping
+from collections.abc import Mapping
 
 import httpx
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,6 +27,7 @@ testpaths = [
     "test_auth.py",
     "test_google_auth.py",
     "test_cross_user_isolation.py",
+    "test_upload_dedup.py",
     "test_byok.py",
     "test_db_adapter.py",
 ]

--- a/backend/test_byok.py
+++ b/backend/test_byok.py
@@ -52,10 +52,12 @@ def test_encrypt_decrypt_roundtrip(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_decrypt_with_wrong_tag_fails(monkeypatch: pytest.MonkeyPatch):
+    from cryptography.exceptions import InvalidTag
+
     byok = _reload_byok(monkeypatch, _b64_key())
     ct, iv, _tag = byok.encrypt("sk-secret")
     bad_tag = base64.b64encode(b"x" * 16).decode()
-    with pytest.raises(Exception):
+    with pytest.raises(InvalidTag):
         byok.decrypt(ct, iv, bad_tag)
 
 

--- a/backend/test_upload_dedup.py
+++ b/backend/test_upload_dedup.py
@@ -1,0 +1,282 @@
+"""Regression tests for the upload dedup logic in `POST /api/bills/upload`.
+
+The upload endpoint tries three matchers, in order:
+  1. Same filename for the same user
+  2. Same provider + same period_start for the same user
+  3. Same provider + same account_number for the same user — but only
+     as a fallback when the new upload has NO period_start to match on,
+     and the existing row also has no period_start
+
+Priority 3 used to fire whenever priority 2 missed, which silently
+collapsed two bills from the same account but different billing periods
+(e.g. January electric vs February electric) into one row, overwriting
+the older month. This file pins the corrected behaviour down.
+
+We don't drive a real PDF/Tesseract here; the parser is monkeypatched
+to return controlled dicts so the tests are deterministic and fast.
+"""
+from __future__ import annotations
+
+import importlib
+import io
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+@pytest.fixture()
+def app(monkeypatch: pytest.MonkeyPatch):
+    """A fresh FastAPI app + TestClient bound to a temp DB and uploads dir.
+
+    The TestClient is entered as a context manager so the app's lifespan
+    handler runs and `init_db()` actually creates the `bills` table.
+    """
+    tmpdir = Path(tempfile.mkdtemp(prefix="utility-dedup-test-"))
+    monkeypatch.setenv("AUTH_SECRET", "x" * 64)
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("DB_PATH", str(tmpdir / "bills.db"))
+    monkeypatch.setenv("UPLOADS_DIR", str(tmpdir / "uploads"))
+    monkeypatch.setenv("PARSER_BACKEND", "tesseract")
+
+    import auth
+    importlib.reload(auth)
+    if "main" in sys.modules:
+        del sys.modules["main"]
+    import main as main_mod
+    with TestClient(main_mod.app) as client:
+        yield main_mod, client
+
+
+def _bearer(main_mod, sub: str = "alice-sub", email: str = "alice@x") -> dict:
+    token = main_mod.auth_mod.create_token(sub=sub, email=email, name=email)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _fake_jpg() -> bytes:
+    """Tiny payload that satisfies the upload size + content-type checks.
+
+    The byte content doesn't matter — `_parse_uploaded_bill` is patched out,
+    so the file is never actually decoded.
+    """
+    return b"\xff\xd8\xff\xe0fake-jpg-bytes"
+
+
+def _upload(client: TestClient, headers: dict, filename: str) -> dict:
+    files = {"file": (filename, io.BytesIO(_fake_jpg()), "image/jpeg")}
+    r = client.post("/api/bills/upload", files=files, headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _patch_parser(main_mod, monkeypatch: pytest.MonkeyPatch, results: list[dict]):
+    """Make `_parse_uploaded_bill` return the next dict from `results`
+    on each call (FIFO). Lets each test script the parser output."""
+    queue = list(results)
+
+    async def _fake(**_kwargs):
+        assert queue, "parser called more times than the test scripted"
+        return queue.pop(0)
+
+    monkeypatch.setattr(main_mod, "_parse_uploaded_bill", _fake)
+
+
+def _list_bills(client: TestClient, headers: dict) -> list[dict]:
+    r = client.get("/api/bills", headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_same_provider_and_account_but_different_periods_do_not_merge(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """The bug: uploading February's bill while January is on file
+    used to overwrite January because both shared provider+account.
+    With the fix, they must both survive as distinct rows."""
+    main_mod, client = app
+    headers = _bearer(main_mod)
+
+    _patch_parser(main_mod, monkeypatch, [
+        {
+            "provider": "Eesti Energia",
+            "amount_eur": 50.0,
+            "period_start": "2026-01-01",
+            "period_end": "2026-01-31",
+            "account_number": "ACC-123",
+        },
+        {
+            "provider": "Eesti Energia",
+            "amount_eur": 65.0,
+            "period_start": "2026-02-01",
+            "period_end": "2026-02-28",
+            "account_number": "ACC-123",
+        },
+    ])
+
+    jan = _upload(client, headers, "january.jpg")
+    feb = _upload(client, headers, "february.jpg")
+
+    assert jan["replaced"] is False
+    assert feb["replaced"] is False, (
+        "February must be a new row, not a replacement of January"
+    )
+    assert jan["id"] != feb["id"]
+
+    bills = _list_bills(client, headers)
+    periods = sorted(b["period_start"] for b in bills)
+    assert periods == ["2026-01-01", "2026-02-01"]
+
+
+def test_same_provider_and_period_replaces_existing(app, monkeypatch: pytest.MonkeyPatch):
+    """Re-uploading the same month's bill (e.g. a clearer scan) should
+    update the existing row in place, keeping its id."""
+    main_mod, client = app
+    headers = _bearer(main_mod)
+
+    _patch_parser(main_mod, monkeypatch, [
+        {
+            "provider": "Eesti Energia",
+            "amount_eur": 50.0,
+            "period_start": "2026-01-01",
+            "period_end": "2026-01-31",
+            "account_number": "ACC-123",
+        },
+        {
+            "provider": "Eesti Energia",
+            "amount_eur": 51.42,  # corrected amount on the cleaner scan
+            "period_start": "2026-01-01",
+            "period_end": "2026-01-31",
+            "account_number": "ACC-123",
+        },
+    ])
+
+    first = _upload(client, headers, "jan-blurry.jpg")
+    second = _upload(client, headers, "jan-clear.jpg")
+
+    assert first["replaced"] is False
+    assert second["replaced"] is True
+    assert first["id"] == second["id"]
+
+    bills = _list_bills(client, headers)
+    assert len(bills) == 1
+    assert bills[0]["amount_eur"] == 51.42
+
+
+def test_same_filename_replaces_existing_even_without_period(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """Priority 1 (filename) should still catch a literal re-upload of
+    the same file even when the parser couldn't extract a period."""
+    main_mod, client = app
+    headers = _bearer(main_mod)
+
+    _patch_parser(main_mod, monkeypatch, [
+        {
+            "provider": "Tallinna Vesi",
+            "amount_eur": 18.0,
+            "account_number": "ACC-9",
+        },
+        {
+            "provider": "Tallinna Vesi",
+            "amount_eur": 18.0,
+            "account_number": "ACC-9",
+        },
+    ])
+
+    first = _upload(client, headers, "water.jpg")
+    second = _upload(client, headers, "water.jpg")
+
+    assert first["replaced"] is False
+    assert second["replaced"] is True
+    assert first["id"] == second["id"]
+
+
+def test_account_number_fallback_only_when_neither_has_period(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """If both uploads have no period_start, the provider+account
+    fallback may merge them (parser-failure re-upload of the same bill).
+    Filename differs so priority 1 doesn't trigger."""
+    main_mod, client = app
+    headers = _bearer(main_mod)
+
+    _patch_parser(main_mod, monkeypatch, [
+        {"provider": "Gasum", "amount_eur": 30.0, "account_number": "G-7"},
+        {"provider": "Gasum", "amount_eur": 30.0, "account_number": "G-7"},
+    ])
+
+    first = _upload(client, headers, "gas-a.jpg")
+    second = _upload(client, headers, "gas-b.jpg")
+
+    assert first["replaced"] is False
+    assert second["replaced"] is True
+    assert first["id"] == second["id"]
+
+
+def test_account_number_fallback_does_not_overwrite_when_existing_has_period(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """If the existing row has a period but the new upload doesn't, we
+    can't tell whether they're the same bill — default to inserting a
+    new row rather than silently overwriting the dated one."""
+    main_mod, client = app
+    headers = _bearer(main_mod)
+
+    _patch_parser(main_mod, monkeypatch, [
+        {
+            "provider": "Gasum",
+            "amount_eur": 30.0,
+            "period_start": "2026-03-01",
+            "period_end": "2026-03-31",
+            "account_number": "G-7",
+        },
+        {"provider": "Gasum", "amount_eur": 30.0, "account_number": "G-7"},
+    ])
+
+    first = _upload(client, headers, "gas-march.jpg")
+    second = _upload(client, headers, "gas-unknown.jpg")
+
+    assert first["replaced"] is False
+    assert second["replaced"] is False
+    assert first["id"] != second["id"]
+
+
+def test_one_users_upload_never_overwrites_another_users_bill(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """Dedup must be scoped per-user. Even with identical provider,
+    account and period, Bob's upload should not touch Alice's row."""
+    main_mod, client = app
+
+    _patch_parser(main_mod, monkeypatch, [
+        {
+            "provider": "Eesti Energia",
+            "amount_eur": 50.0,
+            "period_start": "2026-01-01",
+            "period_end": "2026-01-31",
+            "account_number": "ACC-123",
+        },
+        {
+            "provider": "Eesti Energia",
+            "amount_eur": 99.0,
+            "period_start": "2026-01-01",
+            "period_end": "2026-01-31",
+            "account_number": "ACC-123",
+        },
+    ])
+
+    alice = _upload(client, _bearer(main_mod, "alice-sub", "alice@x"), "jan.jpg")
+    bob = _upload(client, _bearer(main_mod, "bob-sub", "bob@x"), "jan.jpg")
+
+    assert alice["replaced"] is False
+    assert bob["replaced"] is False
+    assert alice["id"] != bob["id"]
+
+    alice_bills = _list_bills(client, _bearer(main_mod, "alice-sub", "alice@x"))
+    assert len(alice_bills) == 1
+    assert alice_bills[0]["amount_eur"] == 50.0


### PR DESCRIPTION
## Summary

The bill-upload endpoint runs three duplicate-detection matchers in order:
1. Same filename
2. Same provider + same `period_start`
3. Same provider + same `account_number`

The third matcher was unintentionally firing as a sequential fallback whenever matcher #2 missed — even when both bills had perfectly valid (but different) `period_start` values. The result: uploading February's electric bill while January's was on file silently overwrote January, because both bills shared provider + account number. The UI even showed the amber "Replaced existing bill" banner for what should have been a brand-new row.

Original commit `cdcef5d` used `if … elif provider and account_number:`, scoping the account-number lookup as a fallback for *parser failure* (no period extracted). Commit `2cba2cb` accidentally refactored this into independent `if not existing_row` checks, which loosened the semantics.

## Fix

`backend/main.py`: restore the elif-style guard. The account-number matcher now only runs when:
- the new upload has no `period_start`, AND
- the existing row has `period_start IS NULL`

If either side has a period, we default to "insert as a new bill" — the user can always delete a duplicate, but they can't un-overwrite a bill.

This matches the behaviour documented in `HelpTab.tsx` ("same filename or same provider + period replaces the previous entry").

## Test plan

Added `backend/test_upload_dedup.py` with 6 regression tests (all monkey-patch the parser so no OCR is required):

- [x] January + February on the same provider+account → both rows survive (the original bug)
- [x] Same provider + same period (clearer scan re-upload) → replaces in place
- [x] Same filename → replaces even when no period was extracted
- [x] Both uploads missing `period_start`, same provider+account → fallback merges them
- [x] Existing row has period, new upload doesn't → does not overwrite
- [x] Cross-user: identical bill from a different user never touches the first user's row

Verified the "different months don't merge" test fails on the old code and passes on the fix. Full backend suite: 60 passed (54 pre-existing + 6 new).

Made with [Cursor](https://cursor.com)