### PR TITLE
fix(upload): include utility_type in dedup so same-provider multi-service bills don't overwrite each other

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -748,6 +748,7 @@ async def upload_bill(
     provider = parsed.get("provider")
     period_start = parsed.get("period_start")
     account_number = parsed.get("account_number")
+    utility_type = parsed.get("utility_type")
 
     replaced = False
     replaced_id: str | None = None
@@ -765,12 +766,24 @@ async def upload_bill(
             existing_row = await c.fetchone()
 
         # 2nd priority: same provider (case-insensitive) + same billing period
+        # + same utility type. The utility_type guard matters when one provider
+        # sends multiple distinct bills in the same month — e.g. Telia phone
+        # and Telia internet, or Eesti Gaas residential heating and gas
+        # cooking. Without it, the second upload would silently overwrite
+        # the first because (provider, period_start) alone matched.
+        # COALESCE-to-empty-string treats two NULL utility_types as equal
+        # (a bill the parser couldn't classify, re-uploaded later) and
+        # treats NULL vs a real type as different (likely two different
+        # bills, one of which the parser failed to classify).
         if not existing_row and provider and period_start:
             async with db.execute(
                 "SELECT id, filename FROM bills "
-                "WHERE LOWER(TRIM(provider)) = LOWER(TRIM(?)) AND period_start = ? AND user_id = ? "
+                "WHERE LOWER(TRIM(provider)) = LOWER(TRIM(?)) "
+                "AND period_start = ? "
+                "AND COALESCE(utility_type, '') = COALESCE(?, '') "
+                "AND user_id = ? "
                 "ORDER BY upload_date DESC LIMIT 1",
-                (provider, period_start, user_id),
+                (provider, period_start, utility_type, user_id),
             ) as c:
                 existing_row = await c.fetchone()
 
@@ -791,9 +804,10 @@ async def upload_bill(
                 "WHERE LOWER(TRIM(provider)) = LOWER(TRIM(?)) "
                 "AND account_number = ? "
                 "AND period_start IS NULL "
+                "AND COALESCE(utility_type, '') = COALESCE(?, '') "
                 "AND user_id = ? "
                 "ORDER BY upload_date DESC LIMIT 1",
-                (provider, account_number, user_id),
+                (provider, account_number, utility_type, user_id),
             ) as c:
                 existing_row = await c.fetchone()
 

--- a/backend/test_upload_dedup.py
+++ b/backend/test_upload_dedup.py
@@ -2,15 +2,22 @@
 
 The upload endpoint tries three matchers, in order:
   1. Same filename for the same user
-  2. Same provider + same period_start for the same user
-  3. Same provider + same account_number for the same user — but only
-     as a fallback when the new upload has NO period_start to match on,
-     and the existing row also has no period_start
+  2. Same provider + same period_start + same utility_type for the same user
+  3. Same provider + same account_number + same utility_type for the same
+     user — but only as a fallback when the new upload has NO period_start
+     to match on, and the existing row also has no period_start
 
-Priority 3 used to fire whenever priority 2 missed, which silently
-collapsed two bills from the same account but different billing periods
-(e.g. January electric vs February electric) into one row, overwriting
-the older month. This file pins the corrected behaviour down.
+Two real-world failure modes pinned down here:
+
+A. Priority 3 used to fire whenever priority 2 missed, which silently
+   collapsed two bills from the same account but different billing
+   periods (Jan electric vs Feb electric) into one row, overwriting
+   the older month.
+
+B. Priority 2 used to ignore utility_type, which silently collapsed
+   two distinct services from the same provider in the same month
+   (Telia phone + Telia internet, or Eesti Gaas heating + cooking)
+   into one row, overwriting the first.
 
 We don't drive a real PDF/Tesseract here; the parser is monkeypatched
 to return controlled dicts so the tests are deterministic and fast.
@@ -280,3 +287,219 @@ def test_one_users_upload_never_overwrites_another_users_bill(
     alice_bills = _list_bills(client, _bearer(main_mod, "alice-sub", "alice@x"))
     assert len(alice_bills) == 1
     assert alice_bills[0]["amount_eur"] == 50.0
+
+
+def test_same_provider_different_utility_types_do_not_merge(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """Real bug from a user report: one provider sending two distinct
+    bills for two distinct services in the same month (e.g. Telia
+    phone + Telia internet) used to be collapsed into one row by
+    priority-2 dedup, which only considered (provider, period). The
+    second upload silently overwrote the first.
+
+    Now: priority 2 also requires utility_type to match, so both bills
+    survive and the user can see / aggregate them separately."""
+    main_mod, client = app
+    headers = _bearer(main_mod)
+
+    _patch_parser(main_mod, monkeypatch, [
+        {
+            "provider": "Telia",
+            "utility_type": "telecom",
+            "amount_eur": 20.0,
+            "period_start": "2026-03-01",
+            "period_end": "2026-03-31",
+        },
+        {
+            "provider": "Telia",
+            "utility_type": "internet",
+            "amount_eur": 30.0,
+            "period_start": "2026-03-01",
+            "period_end": "2026-03-31",
+        },
+    ])
+
+    phone = _upload(client, headers, "telia-phone.jpg")
+    internet = _upload(client, headers, "telia-internet.jpg")
+
+    assert phone["replaced"] is False
+    assert internet["replaced"] is False, (
+        "Telia internet must be a new row, not a replacement of Telia phone"
+    )
+    bills = _list_bills(client, headers)
+    types = sorted((b["utility_type"], b["amount_eur"]) for b in bills)
+    assert types == [("internet", 30.0), ("telecom", 20.0)]
+
+
+def test_same_provider_same_type_same_period_still_dedupes(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """Sanity: the utility_type guard must not break the legitimate
+    same-bill-uploaded-twice case. A re-upload with the same
+    (provider, period, type) should still UPDATE in place rather than
+    inserting a duplicate row."""
+    main_mod, client = app
+    headers = _bearer(main_mod)
+
+    _patch_parser(main_mod, monkeypatch, [
+        {
+            "provider": "Eesti Energia", "utility_type": "electricity",
+            "amount_eur": 50.0,
+            "period_start": "2026-03-01", "period_end": "2026-03-31",
+        },
+        {
+            "provider": "Eesti Energia", "utility_type": "electricity",
+            "amount_eur": 51.42,  # corrected on the cleaner re-scan
+            "period_start": "2026-03-01", "period_end": "2026-03-31",
+        },
+    ])
+
+    first = _upload(client, headers, "eesti-blurry.jpg")
+    second = _upload(client, headers, "eesti-clear.jpg")
+
+    assert first["replaced"] is False
+    assert second["replaced"] is True
+    assert first["id"] == second["id"]
+
+    bills = _list_bills(client, headers)
+    assert len(bills) == 1
+    assert bills[0]["amount_eur"] == 51.42
+
+
+def test_one_known_type_and_one_null_type_do_not_merge(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """Edge case: if the parser correctly classified one bill as
+    `electricity` and failed to classify another (NULL type) from the
+    same provider in the same month, those are most likely two
+    different bills (one of which the parser misclassified) — not the
+    same bill uploaded twice. The strict COALESCE(...) = COALESCE(...)
+    rule keeps them as separate rows so the user can sort it out
+    manually rather than silently losing one."""
+    main_mod, client = app
+    headers = _bearer(main_mod)
+
+    _patch_parser(main_mod, monkeypatch, [
+        {
+            "provider": "Eesti Energia", "utility_type": "electricity",
+            "amount_eur": 50.0,
+            "period_start": "2026-03-01", "period_end": "2026-03-31",
+        },
+        {
+            "provider": "Eesti Energia", "utility_type": None,
+            "amount_eur": 80.0,
+            "period_start": "2026-03-01", "period_end": "2026-03-31",
+        },
+    ])
+
+    a = _upload(client, headers, "a.jpg")
+    b = _upload(client, headers, "b.jpg")
+
+    assert a["replaced"] is False
+    assert b["replaced"] is False
+    assert a["id"] != b["id"]
+    assert len(_list_bills(client, headers)) == 2
+
+
+def test_two_null_types_with_same_provider_and_period_still_dedupe(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """Symmetry check: two re-uploads where the parser failed to
+    classify both should still collapse into one row (same bill, same
+    parser failure). NULL == NULL via COALESCE-to-empty-string."""
+    main_mod, client = app
+    headers = _bearer(main_mod)
+
+    _patch_parser(main_mod, monkeypatch, [
+        {
+            "provider": "Mystery Co", "utility_type": None,
+            "amount_eur": 12.34,
+            "period_start": "2026-03-01", "period_end": "2026-03-31",
+        },
+        {
+            "provider": "Mystery Co", "utility_type": None,
+            "amount_eur": 12.34,
+            "period_start": "2026-03-01", "period_end": "2026-03-31",
+        },
+    ])
+
+    first = _upload(client, headers, "first.jpg")
+    second = _upload(client, headers, "second.jpg")
+
+    assert first["replaced"] is False
+    assert second["replaced"] is True
+    assert len(_list_bills(client, headers)) == 1
+
+
+# ───────── Aggregation: multiple distinct bills in the same month ─────────
+
+def test_multiple_distinct_bills_in_one_month_aggregate_correctly(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """User scenario: separate electricity, heating, and water bills
+    uploaded individually for the same month should all survive and
+    aggregate cleanly in the analytics dashboard:
+
+    - monthly_total: sum of all three amounts for that month
+    - by_type: each bill contributes to its own utility_type row
+    - bill counts and per-type stats: per-bill (not collapsed)
+
+    This is the common multi-utility household case — the README
+    promises it works and this test pins it down."""
+    main_mod, client = app
+    headers = _bearer(main_mod)
+
+    _patch_parser(main_mod, monkeypatch, [
+        {
+            "provider": "Eesti Energia", "utility_type": "electricity",
+            "amount_eur": 50.0,
+            "period_start": "2026-03-01", "period_end": "2026-03-31",
+        },
+        {
+            "provider": "Adven", "utility_type": "heating",
+            "amount_eur": 80.0,
+            "period_start": "2026-03-01", "period_end": "2026-03-31",
+        },
+        {
+            "provider": "Tallinna Vesi", "utility_type": "water",
+            "amount_eur": 30.0,
+            "period_start": "2026-03-01", "period_end": "2026-03-31",
+        },
+    ])
+
+    _upload(client, headers, "electricity.jpg")
+    _upload(client, headers, "heating.jpg")
+    _upload(client, headers, "water.jpg")
+
+    bills = _list_bills(client, headers)
+    assert len(bills) == 3, "All three distinct bills must survive"
+
+    r = client.get("/api/analytics/summary", headers=headers)
+    assert r.status_code == 200
+    payload = r.json()
+
+    by_month = {row["month"]: row for row in payload["monthly_total"]}
+    assert "2026-03" in by_month
+    assert by_month["2026-03"]["total_eur"] == 160.0, (
+        "Monthly total should be sum of all three bills (50 + 80 + 30 = 160)"
+    )
+
+    by_type = {row["utility_type"]: row for row in payload["by_type"]}
+    assert by_type["electricity"]["total_eur"] == 50.0
+    assert by_type["heating"]["total_eur"] == 80.0
+    assert by_type["water"]["total_eur"] == 30.0
+    for utype in ("electricity", "heating", "water"):
+        assert by_type[utype]["bill_count"] == 1, (
+            f"{utype} should have exactly one contributing bill"
+        )
+
+    by_provider = {row["provider"]: row for row in payload["by_provider"]}
+    assert {"Eesti Energia", "Adven", "Tallinna Vesi"}.issubset(by_provider.keys())
+    assert by_provider["Eesti Energia"]["total_eur"] == 50.0
+    assert by_provider["Adven"]["total_eur"] == 80.0
+    assert by_provider["Tallinna Vesi"]["total_eur"] == 30.0
+
+    annual = {row["year"]: row for row in payload["annual_total"]}
+    assert annual["2026"]["bill_count"] == 3
+    assert annual["2026"]["total_eur"] == 160.0


### PR DESCRIPTION
**Reported by user**: separate bills uploaded for different services (electricity, heating, etc.) in the same month — does the app aggregate them correctly?

Investigated both scenarios:

| Scenario | Status |
|---|---|
| Different providers, same month (e.g. Eesti Energia electricity + Adven heating, both March) | ✅ Works — both bills survive, monthly_total / by_type / by_provider all aggregate correctly |
| Same provider, different services, same month (e.g. Telia phone + Telia internet, both March) | ❌ **Bug** — second upload silently overwrites the first |

## Root cause

Priority-2 dedup matched on \`(provider, period_start, user_id)\` only. For the Telia phone+internet case both fields were identical, so the second upload triggered an UPDATE-in-place over the first.

Same-provider multi-service is a real Estonian case — Telia (phone + internet), Eesti Gaas (residential heating + gas cooking), etc.

## Fix

Include \`utility_type\` in priorities 2 and 3:

\`\`\`sql
AND COALESCE(utility_type, '') = COALESCE(?, '')
\`\`\`

Works on both SQLite and Postgres. Treats two NULL types as equal (parser failed both times → same bill, re-uploaded) and treats NULL vs a real type as different (likely two distinct bills, parser misclassified one). Strict-but-safe: false positives now mean the user sees an extra row they can manually delete, rather than losing data silently.

## Test plan

5 new tests in \`backend/test_upload_dedup.py\` (97 backend tests total):

- [x] Same-provider, different utility types → both survive (the bug)
- [x] Same-provider, same type, same period → still dedupes cleanly (sanity)
- [x] One known type + one NULL type → no merge (parser misclassification defaults to "different bills")
- [x] Two NULL types → still dedupe (symmetric NULL handling via COALESCE)
- [x] **End-to-end aggregation**: 3 distinct bills (electricity + heating + water) for the same month survive, sum correctly in \`monthly_total\` (€160), per-type (€50/€80/€30), per-provider, and \`annual_total\` — directly answers the user's "does the app aggregate this correctly?" question

Each new "must-not-merge" test was verified to fail on master and pass with the fix.

Backend suite: **97 passed** (92 + 5 new). Ruff clean.

Made with [Cursor](https://cursor.com)