### PR TITLE
feat: BYOK-only UX with mandatory onboarding + auto-fallback chain

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ import google_auth as google_auth_mod
 from parser import parse_bill as parse_bill_tesseract
 from parser_byok import parse_bill_with_byok
 from parser_freellmapi import parse_bill_with_freellmapi
+from parser_openai_compat import KeyExhaustedError
 from translation import classify_line_item, enrich_parsed
 
 logger = logging.getLogger("utility_tracker")
@@ -167,6 +168,16 @@ async def _init_sqlite(db) -> None:
         await db.execute(
             "ALTER TABLE user_api_keys ADD COLUMN is_default INTEGER NOT NULL DEFAULT 0"
         )
+    # Tracking columns for the auto-fallback chain. `last_used_at` lets
+    # us pick the least-recently-used healthy key (LRU = round-robin
+    # without a counter); `last_error` + `last_error_at` mark a key as
+    # temporarily exhausted so the chain skips it for ~1 hour.
+    if "last_used_at" not in key_cols:
+        await db.execute("ALTER TABLE user_api_keys ADD COLUMN last_used_at TEXT")
+    if "last_error" not in key_cols:
+        await db.execute("ALTER TABLE user_api_keys ADD COLUMN last_error TEXT")
+    if "last_error_at" not in key_cols:
+        await db.execute("ALTER TABLE user_api_keys ADD COLUMN last_error_at TEXT")
 
 
 async def _init_postgres(db) -> None:
@@ -222,6 +233,10 @@ async def _init_postgres(db) -> None:
     await db.execute(
         "ALTER TABLE user_api_keys ADD COLUMN IF NOT EXISTS is_default BOOLEAN NOT NULL DEFAULT false"
     )
+    # Tracking columns for the auto-fallback chain. See SQLite path above.
+    await db.execute("ALTER TABLE user_api_keys ADD COLUMN IF NOT EXISTS last_used_at TEXT")
+    await db.execute("ALTER TABLE user_api_keys ADD COLUMN IF NOT EXISTS last_error TEXT")
+    await db.execute("ALTER TABLE user_api_keys ADD COLUMN IF NOT EXISTS last_error_at TEXT")
     await db.execute("CREATE INDEX IF NOT EXISTS bills_user_id_idx ON bills(user_id)")
     await db.execute("CREATE INDEX IF NOT EXISTS user_api_keys_user_id_idx ON user_api_keys(user_id)")
     # Same partial unique index as on SQLite; without it, two concurrent
@@ -708,6 +723,17 @@ async def upload_bill(
             model=model,
         )
         parsed = enrich_parsed(parsed)  # add translations locally — no API call
+    except HTTPException:
+        # The auto-fallback chain raises HTTPExceptions with structured
+        # details (`no_keys`, `all_keys_exhausted`, per-key `failures`)
+        # that the frontend pattern-matches on. Don't swallow them into
+        # the generic "low_quality" failure path below or that structure
+        # is lost. Tidy up the upload artefact before re-raising.
+        try:
+            os.remove(save_path)
+        except OSError:
+            pass
+        raise
     except Exception as e:
         logger.exception("Bill parsing failed for %s (backend=%s)", filename, effective_parser)
         parse_error = f"{type(e).__name__}: {e}"
@@ -885,6 +911,193 @@ async def upload_bill(
     return {"id": bill_id, "parsed": parsed, "replaced": replaced}
 
 
+# How long to consider a key "exhausted" after a rate-limit / out-of-credits
+# / auth-failed response from upstream. After this window the auto-fallback
+# chain treats the key as healthy again and retries it. One hour balances
+# being responsive (free-tier rate limits typically reset every minute or
+# every day, so we shouldn't overshoot egregiously) and avoiding
+# back-to-back hammering of a provider that just returned 429.
+_BYOK_EXHAUSTED_WINDOW_SEC = 3600.0
+
+
+def _is_key_currently_exhausted(row: dict, now_iso: str | None = None) -> bool:
+    """Whether `row.last_error_at` is recent enough to skip this key in
+    the auto-fallback chain. `last_error_at` older than the cooldown
+    window means the key is presumed healthy again."""
+    err_at = row.get("last_error_at")
+    if not err_at:
+        return False
+    try:
+        err_dt = datetime.fromisoformat(err_at)
+    except (TypeError, ValueError):
+        return False
+    if err_dt.tzinfo is None:
+        err_dt = err_dt.replace(tzinfo=timezone.utc)
+    age = (datetime.now(timezone.utc) - err_dt).total_seconds()
+    return age < _BYOK_EXHAUSTED_WINDOW_SEC
+
+
+async def _list_user_byok_keys_lru(user_id: str) -> list[dict]:
+    """Return all of a user's BYOK keys, ordered for the auto-fallback
+    chain: least-recently-used first (NULL `last_used_at` first), so
+    distributing N uploads across K keys naturally round-robins.
+
+    The healthy/exhausted partition is applied at try-time inside the
+    chain so a key that just exhausted in the same request doesn't get
+    retried — this list is the *ordering*, not the filter.
+    """
+    async with _db() as db:
+        async with db.execute(
+            "SELECT id, user_id, label, provider, encrypted_key, iv, tag, "
+            "default_model, base_url_override, is_default, "
+            "last_used_at, last_error, last_error_at "
+            "FROM user_api_keys WHERE user_id = ? "
+            # NULL last_used_at sorts first across both SQLite and
+            # Postgres because both treat NULL as smaller than any
+            # value in ASC order.
+            "ORDER BY last_used_at ASC NULLS FIRST, created_at ASC"
+            if db_mod.is_postgres()
+            else
+            "SELECT id, user_id, label, provider, encrypted_key, iv, tag, "
+            "default_model, base_url_override, is_default, "
+            "last_used_at, last_error, last_error_at "
+            "FROM user_api_keys WHERE user_id = ? "
+            # SQLite doesn't have NULLS FIRST/LAST; default ASC sort
+            # already places NULLs first, so plain ASC works.
+            "ORDER BY last_used_at ASC, created_at ASC",
+            (user_id,),
+        ) as c:
+            return [dict(r) for r in await c.fetchall()]
+
+
+async def _mark_byok_key_used(user_id: str, key_id: str) -> None:
+    """Record a successful use of `key_id`: clear any prior exhaustion
+    flag and bump `last_used_at` so the round-robin LRU ordering
+    distributes the next upload to a different healthy key."""
+    now = datetime.now(timezone.utc).isoformat()
+    async with _db() as db:
+        await db.execute(
+            "UPDATE user_api_keys "
+            "SET last_used_at = ?, last_error = NULL, last_error_at = NULL "
+            "WHERE id = ? AND user_id = ?",
+            (now, key_id, user_id),
+        )
+        await db.commit()
+
+
+async def _mark_byok_key_exhausted(
+    user_id: str, key_id: str, *, kind: str, message: str,
+) -> None:
+    """Record that `key_id` just failed in a way that warrants skipping
+    it for the rest of the cooldown window. The Settings tab surfaces
+    this as a red badge so the user knows which provider tripped."""
+    now = datetime.now(timezone.utc).isoformat()
+    # Stable code prefix so the frontend can render a typed badge
+    # without parsing free-form text.
+    encoded = f"{kind}: {message}"[:500]
+    async with _db() as db:
+        await db.execute(
+            "UPDATE user_api_keys SET last_error = ?, last_error_at = ? "
+            "WHERE id = ? AND user_id = ?",
+            (encoded, now, key_id, user_id),
+        )
+        await db.commit()
+
+
+def _decrypt_byok_key(row: dict) -> str:
+    """Decrypt a key row's stored ciphertext. Raises a user-friendly
+    RuntimeError on failure so the operator knows the key needs to be
+    re-added (typical cause: BYOK_ENCRYPTION_KEY rotated)."""
+    try:
+        return byok_mod.decrypt(row["encrypted_key"], row["iv"], row["tag"])
+    except Exception as e:
+        raise RuntimeError(
+            "Couldn't decrypt your saved API key. Re-add it from Settings."
+        ) from e
+
+
+async def _parse_with_byok_chain(
+    *, save_path: str, user_id: str, model: str | None,
+) -> dict:
+    """Try the user's BYOK keys in LRU order, marking each as exhausted
+    on rate-limit / out-of-credits / auth failures and falling over to
+    the next one. Raises 422 with an aggregated reason if all keys are
+    exhausted.
+
+    Generic `RuntimeError`s (parsing failures, malformed AI responses,
+    network errors that survived the retry budget) bubble up immediately
+    — trying another key won't help with those.
+    """
+    keys = await _list_user_byok_keys_lru(user_id)
+    if not keys:
+        raise HTTPException(
+            422,
+            detail={
+                "message": (
+                    "No API keys saved yet. Add one in Settings before "
+                    "uploading bills."
+                ),
+                "no_keys": True,
+            },
+        )
+
+    # Try healthy keys first (LRU among them), then exhausted ones as a
+    # last-resort retry — the cooldown window may have expired between
+    # the cached `last_error_at` and now-now.
+    healthy = [k for k in keys if not _is_key_currently_exhausted(k)]
+    exhausted = [k for k in keys if _is_key_currently_exhausted(k)]
+    ordered = healthy + exhausted
+
+    failures: list[dict] = []
+    for key_row in ordered:
+        try:
+            plaintext = _decrypt_byok_key(key_row)
+            parsed = await asyncio.to_thread(
+                parse_bill_with_byok,
+                save_path,
+                provider_id=key_row["provider"],
+                api_key=plaintext,
+                model=model or key_row.get("default_model"),
+                base_url_override=key_row.get("base_url_override"),
+            )
+        except KeyExhaustedError as e:
+            # Mark the key as exhausted so the next upload skips it,
+            # remember the reason for the aggregated error if every
+            # key fails, and fall over to the next key.
+            await _mark_byok_key_exhausted(
+                user_id, key_row["id"], kind=e.kind, message=str(e),
+            )
+            failures.append({
+                "label": key_row["label"],
+                "provider": key_row["provider"],
+                "kind": e.kind,
+                "message": str(e),
+            })
+            logger.info(
+                "BYOK fallback: key %r (%s) exhausted (%s); trying next",
+                key_row["label"], key_row["provider"], e.kind,
+            )
+            continue
+        # Success: clear the exhaustion flag (if any) and update LRU.
+        await _mark_byok_key_used(user_id, key_row["id"])
+        return parsed
+
+    # All keys exhausted. Surface a clear summary so the user knows
+    # which providers tripped and can rotate them in Settings.
+    raise HTTPException(
+        status_code=422,
+        detail={
+            "message": (
+                "All saved API keys are currently rate-limited or rejected "
+                "by their providers. See Settings for per-key status. "
+                "Try again later or add another provider."
+            ),
+            "all_keys_exhausted": True,
+            "failures": failures,
+        },
+    )
+
+
 async def _parse_uploaded_bill(
     *,
     effective_parser: str,
@@ -898,6 +1111,11 @@ async def _parse_uploaded_bill(
     The parsers do CPU-ish OCR work and synchronous HTTP calls, so running them
     directly inside the FastAPI event loop blocks other users while a bill is
     being processed.
+
+    For BYOK, the user can either pin a specific `byok_key_id` (legacy
+    explicit-pick behaviour, still useful for "Test connection") OR
+    omit it and get the auto-fallback chain across all their saved
+    keys. The chain is the default for normal uploads.
     """
     if effective_parser == "claude":
         return await asyncio.to_thread(parse_bill_with_claude, save_path)
@@ -910,22 +1128,32 @@ async def _parse_uploaded_bill(
             model=model or FREELLMAPI_MODEL,
         )
     if effective_parser == "byok":
-        byok_row = await _resolve_byok_key(user_id, byok_key_id or "")
-        try:
-            plaintext_key = byok_mod.decrypt(
-                byok_row["encrypted_key"], byok_row["iv"], byok_row["tag"],
-            )
-        except Exception as e:
-            raise RuntimeError(
-                "Couldn't decrypt your saved API key. Re-add it from Settings."
-            ) from e
-        return await asyncio.to_thread(
-            parse_bill_with_byok,
-            save_path,
-            provider_id=byok_row["provider"],
-            api_key=plaintext_key,
-            model=model or byok_row.get("default_model"),
-            base_url_override=byok_row.get("base_url_override"),
+        if byok_key_id:
+            # User explicitly picked one key — single-shot, no fallback.
+            byok_row = await _resolve_byok_key(user_id, byok_key_id)
+            plaintext_key = _decrypt_byok_key(byok_row)
+            try:
+                parsed = await asyncio.to_thread(
+                    parse_bill_with_byok,
+                    save_path,
+                    provider_id=byok_row["provider"],
+                    api_key=plaintext_key,
+                    model=model or byok_row.get("default_model"),
+                    base_url_override=byok_row.get("base_url_override"),
+                )
+            except KeyExhaustedError as e:
+                # Still record the exhaustion so the badge updates,
+                # then re-raise so the upload fails (the user opted
+                # out of the chain by pinning this key).
+                await _mark_byok_key_exhausted(
+                    user_id, byok_row["id"], kind=e.kind, message=str(e),
+                )
+                raise
+            await _mark_byok_key_used(user_id, byok_row["id"])
+            return parsed
+        # No explicit key: round-robin across the user's saved keys.
+        return await _parse_with_byok_chain(
+            save_path=save_path, user_id=user_id, model=model,
         )
     return await asyncio.to_thread(parse_bill_tesseract, save_path)
 
@@ -1718,12 +1946,21 @@ async def byok_providers():
 
 @app.get("/api/byok-keys")
 async def byok_keys_list(user_id: str = Depends(get_user_id)):
-    """Return the caller's saved keys with masked values — never plaintext."""
+    """Return the caller's saved keys with masked values — never plaintext.
+
+    Each row also carries `is_exhausted` and `last_error` so the
+    Settings tab can show a red "rate limited" badge when the
+    auto-fallback chain has marked a key unhealthy. The frontend
+    can re-derive `is_exhausted` itself from `last_error_at`, but
+    computing it server-side keeps the cooldown window definition
+    in one place.
+    """
     _require_byok_configured()
     async with _db() as db:
         async with db.execute(
             "SELECT id, label, provider, encrypted_key, iv, tag, default_model, "
-            "base_url_override, is_default, created_at "
+            "base_url_override, is_default, created_at, "
+            "last_used_at, last_error, last_error_at "
             "FROM user_api_keys WHERE user_id = ? "
             "ORDER BY is_default DESC, created_at DESC",
             (user_id,),
@@ -1745,6 +1982,10 @@ async def byok_keys_list(user_id: str = Depends(get_user_id)):
             "base_url_override": row["base_url_override"],
             "is_default": bool(row["is_default"]),
             "created_at": row["created_at"],
+            "last_used_at": row["last_used_at"],
+            "last_error": row["last_error"],
+            "last_error_at": row["last_error_at"],
+            "is_exhausted": _is_key_currently_exhausted(dict(row)),
         })
     return out
 

--- a/backend/parser_openai_compat.py
+++ b/backend/parser_openai_compat.py
@@ -22,6 +22,31 @@ import httpx
 
 logger = logging.getLogger("utility_tracker")
 
+
+class KeyExhaustedError(RuntimeError):
+    """The upstream provider rejected this specific API key in a way that
+    makes other keys worth trying — rate limit (429), credit exhaustion
+    (402), or auth failure (401/403). The upload pipeline catches this
+    explicitly so it can mark the key as temporarily unhealthy and fall
+    over to another key in the user's auto-fallback chain.
+
+    Generic `RuntimeError`s (parsing failures, malformed JSON, network
+    timeouts, etc.) keep their existing semantics — they bubble up and
+    fail the upload, since trying another key won't help.
+
+    `kind` is a stable machine-readable code for analytics / UI badging.
+    `message` (carried via the parent class) is the user-facing string.
+    """
+
+    KIND_RATE_LIMIT = "rate_limit"
+    KIND_OUT_OF_CREDITS = "out_of_credits"
+    KIND_AUTH_FAILED = "auth_failed"
+
+    def __init__(self, message: str, *, kind: str):
+        super().__init__(message)
+        self.kind = kind
+
+
 # Big enough for korteriühistu bills with 15+ line items + EN/ET translations.
 DEFAULT_MAX_TOKENS = int(os.environ.get("FREELLMAPI_MAX_TOKENS", 10000))
 MAX_RETRIES = int(os.environ.get("FREELLMAPI_MAX_RETRIES", 3))
@@ -133,6 +158,31 @@ def _is_rate_limit_response(status_code: int, body: object) -> bool:
     return False
 
 
+def _classify_key_exhaustion(status_code: int, body: object) -> str | None:
+    """Classify an upstream failure that warrants falling over to a
+    different key. Returns one of the `KeyExhaustedError.KIND_*` codes
+    or None if the failure looks key-agnostic (network, malformed
+    response, etc.) and trying another key won't help."""
+    if _is_rate_limit_response(status_code, body):
+        return KeyExhaustedError.KIND_RATE_LIMIT
+    if status_code == 402:
+        return KeyExhaustedError.KIND_OUT_OF_CREDITS
+    if status_code in (401, 403):
+        return KeyExhaustedError.KIND_AUTH_FAILED
+    # `insufficient_quota` is OpenAI's typed error for "you're out of
+    # credits"; surface it as out_of_credits even when the HTTP status
+    # itself is non-specific (some gateways return 400 with the typed
+    # body instead of 402).
+    if isinstance(body, dict):
+        err = body.get("error") if isinstance(body.get("error"), dict) else {}
+        err_code = (err.get("code") or err.get("type") or "").lower()
+        if err_code in {"insufficient_quota", "credit_exhausted", "billing_hard_limit_reached"}:
+            return KeyExhaustedError.KIND_OUT_OF_CREDITS
+        if err_code in {"invalid_api_key", "incorrect_api_key", "authentication_error"}:
+            return KeyExhaustedError.KIND_AUTH_FAILED
+    return None
+
+
 def _is_transient_status(status_code: int) -> bool:
     return status_code == 408 or status_code == 425 or 500 <= status_code <= 599
 
@@ -228,8 +278,25 @@ def call_openai_compat_chat(
 
     assert response is not None  # the loop runs at least once
     if not response.is_success:
-        if _is_rate_limit_response(response.status_code, last_detail):
-            raise RuntimeError(_friendly_rate_limit_error(last_detail, source_name))
+        kind = _classify_key_exhaustion(response.status_code, last_detail)
+        if kind is not None:
+            # Upgrade to KeyExhaustedError so the caller's auto-fallback
+            # chain can mark this key as exhausted and try another one.
+            # Generic RuntimeErrors (network glitches, malformed bodies)
+            # are NOT key-specific so they keep failing the upload.
+            if kind == KeyExhaustedError.KIND_RATE_LIMIT:
+                msg = _friendly_rate_limit_error(last_detail, source_name)
+            elif kind == KeyExhaustedError.KIND_OUT_OF_CREDITS:
+                msg = (
+                    f"{source_name} reports this key is out of credits. "
+                    "Top up the provider account, or add another key."
+                )
+            else:  # KIND_AUTH_FAILED
+                msg = (
+                    f"{source_name} rejected this key as invalid. Double-check "
+                    "it in Settings, or delete and re-add."
+                )
+            raise KeyExhaustedError(msg, kind=kind)
         raise RuntimeError(f"{source_name} request failed: {last_detail}")
 
     body = response.json()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,7 @@ testpaths = [
     "test_cross_user_isolation.py",
     "test_upload_dedup.py",
     "test_audit_regressions.py",
+    "test_byok_fallback.py",
     "test_byok.py",
     "test_db_adapter.py",
 ]

--- a/backend/test_byok_fallback.py
+++ b/backend/test_byok_fallback.py
@@ -1,0 +1,438 @@
+"""Regression tests for the BYOK auto-fallback chain.
+
+When a user uploads a bill without pinning a specific `byok_key_id`,
+the backend rotates through their saved keys in LRU order, skipping
+any that were just rate-limited / out-of-credits / auth-failed and
+falling over to the next healthy one. This file pins down:
+
+- The KeyExhaustedError → fall over → next key path
+- LRU ordering (round-robin distributes uploads across healthy keys)
+- 1-hour cooldown window (exhausted keys come back after 1h)
+- Bookkeeping: `last_used_at` updates on success, `last_error` clears
+- All-keys-exhausted ⇒ 422 with a clear summary
+- Per-user isolation (Bob's exhausted state never affects Alice)
+
+We monkeypatch `parse_bill_with_byok` so no real provider calls happen.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import io
+import os
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+@pytest.fixture()
+def app(monkeypatch: pytest.MonkeyPatch):
+    """Fresh FastAPI app + TestClient bound to a temp DB. BYOK is enabled
+    via a throwaway encryption key so the create-key endpoints work."""
+    tmpdir = Path(tempfile.mkdtemp(prefix="byok-fallback-test-"))
+    monkeypatch.setenv("AUTH_SECRET", "x" * 64)
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY",
+                       "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+    monkeypatch.setenv("DB_PATH", str(tmpdir / "bills.db"))
+    monkeypatch.setenv("UPLOADS_DIR", str(tmpdir / "uploads"))
+    # The new UI always sends parser=byok, but for the bare-bones
+    # TestClient calls below we let PARSER_BACKEND default it to
+    # byok too — saves repeating `data={"parser": "byok"}` in every
+    # `_upload` invocation.
+    monkeypatch.setenv("PARSER_BACKEND", "byok")
+
+    import auth
+    importlib.reload(auth)
+    if "main" in sys.modules:
+        del sys.modules["main"]
+    import main as main_mod
+    with TestClient(main_mod.app) as client:
+        yield main_mod, client
+
+
+def _bearer(main_mod, sub: str = "alice-sub", email: str = "alice@x") -> dict:
+    token = main_mod.auth_mod.create_token(sub=sub, email=email, name=email)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _add_key(client: TestClient, headers: dict, label: str, **overrides) -> str:
+    body = {
+        "label": label,
+        "provider": overrides.pop("provider", "groq"),
+        "key": overrides.pop("key", "sk-test-1234567890abcdef"),
+        "is_default": overrides.pop("is_default", False),
+        **overrides,
+    }
+    r = client.post("/api/byok-keys", json=body, headers=headers)
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def _fake_jpg() -> bytes:
+    return b"\xff\xd8\xff\xe0fake-jpg-bytes"
+
+
+def _upload(client: TestClient, headers: dict, filename: str = "x.jpg") -> dict:
+    files = {"file": (filename, io.BytesIO(_fake_jpg()), "image/jpeg")}
+    r = client.post("/api/bills/upload", files=files, headers=headers)
+    return r
+
+
+def _patch_byok_parser(main_mod, monkeypatch: pytest.MonkeyPatch, behaviours: list):
+    """Each call to `parse_bill_with_byok` consumes the next entry from
+    `behaviours` — either a dict to return or an Exception to raise.
+    The test fully scripts what each key's attempt looks like, so we
+    can simulate "key A is rate-limited but key B succeeds" cleanly."""
+    queue = list(behaviours)
+    calls: list[dict] = []
+
+    def _fake(file_path: str, *, provider_id, api_key, model, base_url_override):
+        calls.append({"provider": provider_id, "model": model, "key": api_key})
+        assert queue, "parser called more times than the test scripted"
+        next_step = queue.pop(0)
+        if isinstance(next_step, BaseException):
+            raise next_step
+        return next_step
+
+    monkeypatch.setattr(main_mod, "parse_bill_with_byok", _fake)
+    return calls
+
+
+def _ok_parsed(provider: str = "Test Provider") -> dict:
+    """A minimally valid parsed-bill dict that survives the upload
+    pipeline's "has_useful_data" gate."""
+    return {
+        "provider": provider,
+        "utility_type": "electricity",
+        "amount_eur": 25.0,
+        "period_start": "2026-04-01",
+        "period_end": "2026-04-30",
+    }
+
+
+def _list_keys(client: TestClient, headers: dict) -> list[dict]:
+    r = client.get("/api/byok-keys", headers=headers)
+    assert r.status_code == 200
+    return r.json()
+
+
+# ───────────── KeyExhaustedError vs RuntimeError discrimination ─────────────
+
+def test_key_exhausted_error_carries_kind():
+    """The exception class needs both a user-facing message AND a stable
+    `kind` field so the chain can record what tripped each key."""
+    from parser_openai_compat import KeyExhaustedError
+
+    e = KeyExhaustedError("rate limited", kind=KeyExhaustedError.KIND_RATE_LIMIT)
+    assert isinstance(e, RuntimeError)
+    assert str(e) == "rate limited"
+    assert e.kind == "rate_limit"
+
+
+def test_classify_key_exhaustion_recognises_typed_error_envelopes():
+    """`_classify_key_exhaustion` is the heuristic that decides whether
+    a non-200 response is key-specific (try another) or generic
+    (fail the upload). It must catch the typed error codes the major
+    OpenAI-compatible providers use."""
+    from parser_openai_compat import KeyExhaustedError, _classify_key_exhaustion
+
+    # OpenAI's "out of credits" body comes back as 429 sometimes,
+    # 400 with `insufficient_quota` other times — both should resolve
+    # to "out of credits" and get the chain to fall over.
+    body = {"error": {"code": "insufficient_quota", "message": "..."}}
+    assert _classify_key_exhaustion(400, body) == KeyExhaustedError.KIND_OUT_OF_CREDITS
+
+    # 401 with `invalid_api_key` → auth failed
+    body = {"error": {"code": "invalid_api_key", "message": "..."}}
+    assert _classify_key_exhaustion(401, body) == KeyExhaustedError.KIND_AUTH_FAILED
+
+    # Plain 429 → rate limited (no body needed)
+    assert _classify_key_exhaustion(429, None) == KeyExhaustedError.KIND_RATE_LIMIT
+
+    # Generic 500 with no typed body → None (don't try another key,
+    # this is upstream flake not a key issue)
+    assert _classify_key_exhaustion(500, "Internal Server Error") is None
+
+
+# ─────────────────── Round-robin / LRU ordering ───────────────────
+
+def test_first_upload_picks_least_recently_used_key(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """Two keys, both freshly created (NULL `last_used_at`). Tie-break
+    on `created_at`, so the older one is picked first. After it
+    succeeds, the second upload hits the OTHER key (LRU rotation)."""
+    main_mod, client = app
+    headers = _bearer(main_mod)
+
+    a = _add_key(client, headers, "groq-a", key="sk-key-aaaaaaaaaa")
+    _add_key(client, headers, "groq-b", key="sk-key-bbbbbbbbbb")  # noqa: F841 — id checked via call inspection
+
+    calls = _patch_byok_parser(main_mod, monkeypatch, [
+        _ok_parsed(),
+        _ok_parsed(),
+    ])
+
+    r1 = _upload(client, headers, "first.jpg")
+    assert r1.status_code == 200, r1.text
+    r2 = _upload(client, headers, "second.jpg")
+    assert r2.status_code == 200, r2.text
+
+    # First call should have used the older key (a), then rotated to b
+    # because a's last_used_at is now newer than b's NULL.
+    assert calls[0]["key"] == "sk-key-aaaaaaaaaa"
+    assert calls[1]["key"] == "sk-key-bbbbbbbbbb"
+
+    # And the bookkeeping: both keys have `last_used_at` set, both have
+    # cleared `last_error`, and the first-used key (a) shows up before
+    # the second since it was used earlier.
+    keys_now = {k["label"]: k for k in _list_keys(client, headers)}
+    assert keys_now["groq-a"]["last_used_at"]
+    assert keys_now["groq-b"]["last_used_at"]
+    assert keys_now["groq-a"]["last_used_at"] < keys_now["groq-b"]["last_used_at"]
+    assert keys_now["groq-a"]["last_error"] is None
+    assert keys_now["groq-b"]["last_error"] is None
+    assert all(not k["is_exhausted"] for k in keys_now.values())
+    # Cross-check against the row id we inserted first.
+    assert any(k["id"] == a for k in keys_now.values())
+
+
+# ─────────────────── Fallback on KeyExhaustedError ───────────────────
+
+def test_rate_limited_first_key_falls_over_to_second_key(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """The first-tried key returns 429; the chain catches
+    `KeyExhaustedError`, marks that key exhausted in the DB, and
+    immediately retries with the next key. The user sees a clean 200
+    upload result — they never know the first key tripped."""
+    from parser_openai_compat import KeyExhaustedError
+
+    main_mod, client = app
+    headers = _bearer(main_mod)
+    _add_key(client, headers, "groq-a", key="sk-key-aaaaaaaaaa")
+    _add_key(client, headers, "groq-b", key="sk-key-bbbbbbbbbb")
+
+    calls = _patch_byok_parser(main_mod, monkeypatch, [
+        KeyExhaustedError(
+            "groq rate limit hit", kind=KeyExhaustedError.KIND_RATE_LIMIT,
+        ),
+        _ok_parsed(),
+    ])
+
+    r = _upload(client, headers, "test.jpg")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["parsed"]["provider"] == "Test Provider"
+
+    assert len(calls) == 2  # one failed attempt, then one succeeded
+    keys = {k["label"]: k for k in _list_keys(client, headers)}
+    assert keys["groq-a"]["is_exhausted"] is True
+    assert keys["groq-a"]["last_error"].startswith("rate_limit:")
+    assert keys["groq-b"]["is_exhausted"] is False
+    assert keys["groq-b"]["last_error"] is None
+
+
+def test_out_of_credits_falls_over_with_typed_kind(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """An out-of-credits failure should mark the key with the
+    `out_of_credits` kind (not `rate_limit`), so the Settings tab can
+    show a different badge."""
+    from parser_openai_compat import KeyExhaustedError
+
+    main_mod, client = app
+    headers = _bearer(main_mod)
+    _add_key(client, headers, "openai-a", provider="openai", key="sk-key-aaaaaaaaaa")
+    _add_key(client, headers, "openai-b", provider="openai", key="sk-key-bbbbbbbbbb")
+
+    _patch_byok_parser(main_mod, monkeypatch, [
+        KeyExhaustedError(
+            "out of credits", kind=KeyExhaustedError.KIND_OUT_OF_CREDITS,
+        ),
+        _ok_parsed(),
+    ])
+
+    r = _upload(client, headers)
+    assert r.status_code == 200, r.text
+
+    keys = {k["label"]: k for k in _list_keys(client, headers)}
+    assert keys["openai-a"]["last_error"].startswith("out_of_credits:")
+    assert keys["openai-a"]["is_exhausted"] is True
+
+
+def test_all_keys_exhausted_returns_422_with_summary(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """When every key in the chain raises KeyExhaustedError, the upload
+    must surface a 422 with `all_keys_exhausted: True` and a list of
+    per-key failures so the frontend can show a clear "all keys
+    rate-limited" banner."""
+    from parser_openai_compat import KeyExhaustedError
+
+    main_mod, client = app
+    headers = _bearer(main_mod)
+    _add_key(client, headers, "groq-a", key="sk-key-aaaaaaaaaa")
+    _add_key(client, headers, "groq-b", key="sk-key-bbbbbbbbbb")
+
+    _patch_byok_parser(main_mod, monkeypatch, [
+        KeyExhaustedError("a rate limited", kind=KeyExhaustedError.KIND_RATE_LIMIT),
+        KeyExhaustedError("b rate limited", kind=KeyExhaustedError.KIND_RATE_LIMIT),
+    ])
+
+    r = _upload(client, headers)
+    assert r.status_code == 422, r.text
+    detail = r.json()["detail"]
+    assert detail["all_keys_exhausted"] is True
+    assert len(detail["failures"]) == 2
+    labels = {f["label"] for f in detail["failures"]}
+    assert labels == {"groq-a", "groq-b"}
+
+    # Both keys are now flagged in the listing so the Settings tab
+    # can render two red badges.
+    keys = {k["label"]: k for k in _list_keys(client, headers)}
+    assert keys["groq-a"]["is_exhausted"] is True
+    assert keys["groq-b"]["is_exhausted"] is True
+
+
+def test_no_keys_at_all_returns_helpful_422(app, monkeypatch: pytest.MonkeyPatch):
+    """A user with zero keys hitting the auto-fallback chain should
+    get a clear 'add a key first' error rather than the generic
+    'all keys exhausted' message — the frontend's onboarding gate
+    should normally prevent this, but the backend defends in depth."""
+    main_mod, client = app
+    headers = _bearer(main_mod)
+    _patch_byok_parser(main_mod, monkeypatch, [])
+
+    r = _upload(client, headers)
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    assert detail.get("no_keys") is True
+
+
+# ─────────────────── Cooldown window ───────────────────
+
+def test_exhausted_key_skipped_until_cooldown_expires(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """A key whose `last_error_at` is within the 1-hour cooldown is
+    skipped at the start of the next request. After the cooldown
+    elapses (we simulate it by writing an old `last_error_at`
+    directly), the key is treated as healthy again and tried first
+    (LRU favours not-recently-used)."""
+    from parser_openai_compat import KeyExhaustedError
+
+    main_mod, client = app
+    headers = _bearer(main_mod)
+    a = _add_key(client, headers, "groq-a", key="sk-key-aaaaaaaaaa")
+    _add_key(client, headers, "groq-b", key="sk-key-bbbbbbbbbb")
+
+    # First upload: a is rate-limited, b succeeds.
+    _patch_byok_parser(main_mod, monkeypatch, [
+        KeyExhaustedError("rate limit", kind=KeyExhaustedError.KIND_RATE_LIMIT),
+        _ok_parsed(),
+    ])
+    r = _upload(client, headers, "first.jpg")
+    assert r.status_code == 200
+
+    # Second upload: a is still in cooldown, so the chain skips it
+    # entirely and goes straight to b.
+    calls = _patch_byok_parser(main_mod, monkeypatch, [_ok_parsed()])
+    r = _upload(client, headers, "second.jpg")
+    assert r.status_code == 200
+    assert len(calls) == 1
+    assert calls[0]["key"] == "sk-key-bbbbbbbbbb"
+
+    # Now expire a's cooldown by backdating `last_error_at` past 1 hour.
+    old = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    async def _backdate():
+        async with main_mod._db() as db:
+            await db.execute(
+                "UPDATE user_api_keys SET last_error_at = ? WHERE id = ?",
+                (old, a),
+            )
+            await db.commit()
+    asyncio.run(_backdate())
+
+    # Third upload: a should now be tried first (LRU — its
+    # `last_used_at` is older / null compared to b's recent one).
+    calls = _patch_byok_parser(main_mod, monkeypatch, [_ok_parsed()])
+    r = _upload(client, headers, "third.jpg")
+    assert r.status_code == 200
+    assert calls[0]["key"] == "sk-key-aaaaaaaaaa"
+
+
+# ─────────────────── Per-user isolation ───────────────────
+
+def test_one_users_exhausted_keys_dont_affect_another_user(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """Bob's keys must not be visible to or affected by Alice's
+    upload, ever — the same per-user scoping invariant we test for
+    bills extends to BYOK key state."""
+    from parser_openai_compat import KeyExhaustedError
+
+    main_mod, client = app
+    alice = _bearer(main_mod, "alice-sub", "alice@x")
+    bob = _bearer(main_mod, "bob-sub", "bob@x")
+
+    _add_key(client, alice, "alice-key", key="sk-alice-aaaaaaaaaa")
+    _add_key(client, bob, "bob-key", key="sk-bob-bbbbbbbbbb")
+
+    # Alice's upload exhausts her only key. Bob's key must remain
+    # untouched in the DB.
+    _patch_byok_parser(main_mod, monkeypatch, [
+        KeyExhaustedError("alice rate limit", kind=KeyExhaustedError.KIND_RATE_LIMIT),
+    ])
+    r = _upload(client, alice)
+    assert r.status_code == 422
+
+    alice_keys = _list_keys(client, alice)
+    bob_keys = _list_keys(client, bob)
+    assert alice_keys[0]["is_exhausted"] is True
+    assert bob_keys[0]["is_exhausted"] is False
+    assert bob_keys[0]["last_error"] is None
+
+
+# ─────────────────── Pinned-key behaviour (no fallback) ───────────────────
+
+def test_explicit_byok_key_id_does_not_fall_over(
+    app, monkeypatch: pytest.MonkeyPatch
+):
+    """When the user pins a specific `byok_key_id` (legacy explicit
+    pick), the auto-fallback chain is bypassed and the upload fails if
+    that one key fails. The exhausted state is still recorded so the
+    Settings badge updates, but no other key is tried."""
+    from parser_openai_compat import KeyExhaustedError
+
+    main_mod, client = app
+    headers = _bearer(main_mod)
+    a = _add_key(client, headers, "groq-a", key="sk-key-aaaaaaaaaa")
+    _add_key(client, headers, "groq-b", key="sk-key-bbbbbbbbbb")  # exists but should NOT be tried
+
+    calls = _patch_byok_parser(main_mod, monkeypatch, [
+        KeyExhaustedError("rate limit", kind=KeyExhaustedError.KIND_RATE_LIMIT),
+    ])
+
+    files = {"file": ("x.jpg", io.BytesIO(_fake_jpg()), "image/jpeg")}
+    r = client.post(
+        "/api/bills/upload",
+        files=files,
+        data={"parser": "byok", "byok_key_id": a},
+        headers=headers,
+    )
+    assert r.status_code == 422
+    assert len(calls) == 1, "Pinned byok_key_id must not fall over to other keys"
+
+    # The pinned key's exhausted flag is still set so the user can see
+    # in Settings what just happened.
+    keys = {k["label"]: k for k in _list_keys(client, headers)}
+    assert keys["groq-a"]["is_exhausted"] is True
+    assert keys["groq-b"]["is_exhausted"] is False

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import HelpTab from "./components/HelpTab";
 import CommunityTab from "./components/CommunityTab";
 import SettingsTab from "./components/SettingsTab";
 import LoginScreen from "./components/LoginScreen";
+import OnboardingScreen from "./components/OnboardingScreen";
 import ErrorBoundary from "./components/ErrorBoundary";
 import ThemeToggle from "./components/ThemeToggle";
 import {
@@ -20,6 +21,11 @@ import { useTheme } from "./theme";
 
 type Tab = "upload" | "bills" | "analytics" | "community" | "settings" | "help";
 type AuthState = "loading" | "required" | "authed";
+// 'unknown' = haven't checked yet (still loading the keys count); 'none'
+// = freshly-signed-in user with zero saved BYOK keys, blocks the rest of
+// the app behind <OnboardingScreen/>; 'has_keys' = at least one key, app
+// runs normally.
+type OnboardingState = "unknown" | "none" | "has_keys";
 const TABS: Tab[] = ["upload", "bills", "analytics", "community", "settings", "help"];
 
 function tabFromHash(): Tab {
@@ -44,6 +50,10 @@ export default function App() {
   const [authState, setAuthState] = useState<AuthState>(() =>
     getToken() ? "loading" : "required",
   );
+  // Tracks whether the user has at least one BYOK key. Until the keys
+  // request resolves we render the loading splash; if the user has
+  // zero keys we gate the app behind the onboarding screen.
+  const [onboardingState, setOnboardingState] = useState<OnboardingState>("unknown");
   const [me, setMe] = useState<User | null>(null);
   const [profileOpen, setProfileOpen] = useState(false);
   const profileBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -95,6 +105,7 @@ export default function App() {
     const onLogout = () => {
       setMe(null);
       setAuthState("required");
+      setOnboardingState("unknown");
     };
     window.addEventListener("auth:logout", onLogout);
     return () => {
@@ -102,6 +113,33 @@ export default function App() {
       window.removeEventListener("auth:logout", onLogout);
     };
   }, []);
+
+  // Once authed, check whether the user has any BYOK keys. Zero keys
+  // means we gate the rest of the app behind <OnboardingScreen/>;
+  // otherwise the normal tab UI mounts. We deliberately fail-open
+  // (treat fetch errors as "has_keys") so a transient network blip
+  // can't lock an existing user out of their data.
+  useEffect(() => {
+    if (authState !== "authed") return;
+    let cancelled = false;
+    api
+      .listMyByokKeys()
+      .then((res) => {
+        if (cancelled) return;
+        const keys = res.data ?? [];
+        setOnboardingState(keys.length === 0 ? "none" : "has_keys");
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        // If BYOK isn't configured at all (503), don't strand the user
+        // on an onboarding screen they can't satisfy — let them through
+        // to the rest of the app, where the Settings tab will surface
+        // the configuration warning instead.
+        setOnboardingState("has_keys");
+        console.warn("Couldn't load BYOK keys:", e);
+      });
+    return () => { cancelled = true; };
+  }, [authState]);
 
   const onLoginSuccess = () => {
     api
@@ -113,11 +151,16 @@ export default function App() {
       .catch(() => setAuthState("required"));
   };
 
+  const onFirstKeyAdded = () => {
+    setOnboardingState("has_keys");
+  };
+
   const logout = () => {
     clearToken();
     setMe(null);
     setProfileOpen(false);
     setAuthState("required");
+    setOnboardingState("unknown");
   };
 
   // Track the trigger button's viewport rect while the menu is open so
@@ -143,7 +186,7 @@ export default function App() {
     };
   }, [profileOpen]);
 
-  if (authState === "loading") {
+  if (authState === "loading" || (authState === "authed" && onboardingState === "unknown")) {
     return (
       <div
         style={{
@@ -162,6 +205,17 @@ export default function App() {
 
   if (authState === "required") {
     return <LoginScreen onSuccess={onLoginSuccess} />;
+  }
+
+  // Authed but no BYOK keys: block the rest of the app until the user
+  // adds their first one. Without this gate, new users land on a
+  // non-functional Upload tab and assume the app is broken.
+  if (onboardingState === "none") {
+    return (
+      <div style={{ minHeight: "100vh", background: "var(--bg)", color: "var(--text-1)" }}>
+        <OnboardingScreen onKeyAdded={onFirstKeyAdded} />
+      </div>
+    );
   }
 
   return (

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -103,6 +103,21 @@ export interface ByokKey {
   /** True when this key is the per-provider default for the user. */
   is_default: boolean;
   created_at: string;
+  /** ISO timestamp of the most recent successful upload using this key,
+   *  or null if it has never been used. Drives the LRU round-robin
+   *  selection in the auto-fallback chain. */
+  last_used_at: string | null;
+  /** Human-readable reason why the auto-fallback chain marked this key
+   *  exhausted (rate limited / out of credits / auth failed) — null
+   *  when the key is healthy. The Settings tab surfaces this as a
+   *  red badge. */
+  last_error: string | null;
+  /** ISO timestamp of `last_error`. */
+  last_error_at: string | null;
+  /** Server-computed: true when `last_error_at` falls inside the
+   *  cooldown window (1h) so the chain is currently skipping this
+   *  key. Falls back to false once the window elapses. */
+  is_exhausted: boolean;
 }
 
 export interface ByokProbeResult {

--- a/frontend/src/components/OnboardingScreen.tsx
+++ b/frontend/src/components/OnboardingScreen.tsx
@@ -1,0 +1,399 @@
+import { useEffect, useMemo, useState } from "react";
+import { Key, ExternalLink, Loader2, AlertCircle, Eye, EyeOff, Sparkles, Wifi } from "lucide-react";
+import axios from "axios";
+import { api, type ByokProvider } from "../api";
+
+interface Props {
+  onKeyAdded: () => void;
+}
+
+const cardStyle: React.CSSProperties = {
+  background: "var(--surface-1)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius)",
+  padding: 24,
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  background: "var(--surface-2)",
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  color: "var(--text-1)",
+  padding: "10px 12px",
+  fontSize: 14,
+};
+
+const buttonPrimary: React.CSSProperties = {
+  background: "var(--accent)",
+  color: "white",
+  border: "none",
+  borderRadius: 8,
+  padding: "10px 18px",
+  fontSize: 14,
+  fontWeight: 600,
+  cursor: "pointer",
+};
+
+// Curated set of recommended free providers for new users. Every entry
+// here exists in `byok.PROVIDERS` on the backend; the onboarding page
+// is intentionally narrower than the full Settings list — too many
+// choices on the very first screen would be paralysing.
+const RECOMMENDED_PROVIDER_IDS = ["groq", "google", "cerebras", "openrouter"];
+
+/**
+ * Full-screen onboarding gate shown once a freshly-signed-in user has
+ * zero saved BYOK keys. Adding even one key dismisses the gate and
+ * unlocks the rest of the app.
+ *
+ * The app needs at least one provider key to parse uploaded bills,
+ * since we don't ship a managed parsing backend. We funnel new users
+ * here rather than letting them land on a non-functional Upload tab,
+ * which used to confuse people into thinking the app was broken.
+ */
+export default function OnboardingScreen({ onKeyAdded }: Props) {
+  const [providers, setProviders] = useState<ByokProvider[]>([]);
+  const [providerId, setProviderId] = useState<string>("");
+  // Onboarding intentionally doesn't ask for a label — the user can
+  // edit it later in Settings. We auto-fill it with the provider name
+  // on submit so the saved key still has a sensible display string.
+  const [secret, setSecret] = useState("");
+  const [model, setModel] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [showSecret, setShowSecret] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [probing, setProbing] = useState(false);
+  const [probeMsg, setProbeMsg] = useState<{ ok: boolean; text: string } | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [loadingProviders, setLoadingProviders] = useState(true);
+  const [providersErr, setProvidersErr] = useState<string | null>(null);
+
+  // Pull the provider catalogue from the backend on mount. The
+  // catalogue is anonymous-public so this works even before the user
+  // has any keys saved.
+  useEffect(() => {
+    let cancelled = false;
+    api.listByokProviders()
+      .then((res) => {
+        if (cancelled) return;
+        const all = res.data.providers ?? [];
+        if (all.length === 0) {
+          setProvidersErr(
+            "BYOK isn't configured on this deployment. Ask the operator to set BYOK_ENCRYPTION_KEY.",
+          );
+          return;
+        }
+        setProviders(all);
+        // Default to Groq if available — generous free tier, fastest.
+        const recommended = all.find((p) => p.id === "groq") ?? all[0];
+        setProviderId(recommended.id);
+        setModel(recommended.default_model);
+        setBaseUrl(recommended.base_url);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        if (axios.isAxiosError(e) && e.response?.status === 503) {
+          setProvidersErr(
+            "BYOK isn't configured on this deployment. Ask the operator to set BYOK_ENCRYPTION_KEY.",
+          );
+        } else {
+          setProvidersErr("Couldn't load the provider list.");
+        }
+      })
+      .finally(() => { if (!cancelled) setLoadingProviders(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const provider = useMemo(
+    () => providers.find((p) => p.id === providerId) ?? null,
+    [providers, providerId],
+  );
+
+  // Show the "recommended for new users" subset first, then the rest.
+  // Keeps the onboarding picker uncluttered while still letting power
+  // users pick anything (e.g. their existing OpenAI account).
+  const orderedProviders = useMemo(() => {
+    if (providers.length === 0) return [];
+    const recommended = RECOMMENDED_PROVIDER_IDS
+      .map((id) => providers.find((p) => p.id === id))
+      .filter((p): p is ByokProvider => Boolean(p));
+    const rest = providers.filter((p) => !RECOMMENDED_PROVIDER_IDS.includes(p.id));
+    return [...recommended, ...rest];
+  }, [providers]);
+
+  const onProviderChange = (id: string) => {
+    setProviderId(id);
+    const p = providers.find((prov) => prov.id === id);
+    if (p) {
+      setModel(p.default_model);
+      setBaseUrl(p.base_url);
+    }
+    setProbeMsg(null);
+  };
+
+  const onProbe = async () => {
+    if (!provider) return;
+    setProbing(true);
+    setProbeMsg(null);
+    try {
+      const res = await api.probeByokKey({
+        provider: provider.id,
+        key: secret.trim() || undefined,
+        base_url: baseUrl.trim() || undefined,
+      });
+      setProbeMsg({ ok: res.data.ok, text: res.data.message });
+    } catch (e) {
+      const msg = axios.isAxiosError(e)
+        ? ((e.response?.data as { detail?: string } | undefined)?.detail ?? e.message)
+        : "Network error.";
+      setProbeMsg({ ok: false, text: msg });
+    } finally {
+      setProbing(false);
+    }
+  };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!provider) return;
+    setSaving(true);
+    setErr(null);
+    try {
+      // Auto-fill label with provider name — onboarding deliberately
+      // doesn't ask for one. The user can rename later in Settings.
+      const effectiveLabel = `${provider.name} (default)`;
+      await api.addByokKey({
+        provider: provider.id,
+        label: effectiveLabel,
+        key: secret.trim(),
+        default_model: model.trim() || undefined,
+        base_url: baseUrl.trim() || undefined,
+        is_default: true,  // first key is automatically the default
+      });
+      onKeyAdded();
+    } catch (e) {
+      if (axios.isAxiosError(e) && e.response?.data) {
+        const detail = (e.response.data as { detail?: string }).detail;
+        setErr(typeof detail === "string" ? detail : "Couldn't save the key.");
+      } else {
+        setErr("Network error. Try again.");
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loadingProviders) {
+    return (
+      <div style={{ display: "flex", justifyContent: "center", padding: 60 }}>
+        <Loader2 size={28} style={{ color: "var(--accent)", animation: "spin 1s linear infinite" }} />
+      </div>
+    );
+  }
+
+  if (providersErr) {
+    return (
+      <div style={{ ...cardStyle, maxWidth: 600, margin: "60px auto", borderColor: "var(--danger)" }}>
+        <div style={{ display: "flex", gap: 12, alignItems: "flex-start" }}>
+          <AlertCircle size={24} style={{ color: "var(--danger)", flexShrink: 0, marginTop: 2 }} />
+          <div>
+            <h2 style={{ margin: "0 0 6px", fontSize: 18 }}>BYOK not configured</h2>
+            <p style={{ margin: 0, color: "var(--text-2)" }}>{providersErr}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ maxWidth: 720, margin: "32px auto", padding: "0 16px" }}>
+      <div style={{ textAlign: "center", marginBottom: 28 }}>
+        <div style={{
+          display: "inline-flex", alignItems: "center", justifyContent: "center",
+          width: 56, height: 56, borderRadius: 14, background: "var(--accent-soft)",
+          marginBottom: 12,
+        }}>
+          <Key size={28} style={{ color: "var(--accent)" }} />
+        </div>
+        <h1 style={{ margin: "0 0 8px", fontSize: 24 }}>One last step — add an AI key</h1>
+        <p style={{ margin: 0, color: "var(--text-2)", fontSize: 15, lineHeight: 1.5 }}>
+          Bills are parsed with whichever AI provider you choose. Pick a free one
+          below and paste your API key — it's encrypted at rest before being saved.
+        </p>
+      </div>
+
+      <div style={{ ...cardStyle, marginBottom: 16 }}>
+        <div style={{ display: "flex", gap: 10, alignItems: "center", marginBottom: 12, color: "var(--text-2)", fontSize: 13 }}>
+          <Sparkles size={16} style={{ color: "var(--accent)" }} />
+          <span>Recommended free providers</span>
+        </div>
+
+        <form onSubmit={onSubmit} style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <div>
+            <label style={{ display: "block", fontSize: 13, fontWeight: 600, marginBottom: 6 }}>
+              Provider
+            </label>
+            <select
+              value={providerId}
+              onChange={(e) => onProviderChange(e.target.value)}
+              style={{ ...inputStyle, cursor: "pointer" }}
+            >
+              {orderedProviders.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                  {RECOMMENDED_PROVIDER_IDS.includes(p.id) ? " — free tier" : ""}
+                </option>
+              ))}
+            </select>
+            {provider?.key_url && (
+              <a
+                href={provider.key_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: "inline-flex", alignItems: "center", gap: 4,
+                  marginTop: 6, fontSize: 12, color: "var(--accent)", textDecoration: "none",
+                }}
+              >
+                Get a {provider.name} key <ExternalLink size={12} />
+              </a>
+            )}
+          </div>
+
+          <div>
+            <label style={{ display: "block", fontSize: 13, fontWeight: 600, marginBottom: 6 }}>
+              API key {provider?.allows_empty_key && <span style={{ color: "var(--text-3)", fontWeight: 400 }}>(optional for this provider)</span>}
+            </label>
+            <div style={{ position: "relative" }}>
+              <input
+                type={showSecret ? "text" : "password"}
+                value={secret}
+                onChange={(e) => setSecret(e.target.value)}
+                placeholder={provider?.key_hint ?? "sk-..."}
+                style={{ ...inputStyle, paddingRight: 40, fontFamily: "monospace" }}
+                autoComplete="off"
+                spellCheck={false}
+              />
+              <button
+                type="button"
+                onClick={() => setShowSecret((s) => !s)}
+                style={{
+                  position: "absolute", right: 8, top: "50%", transform: "translateY(-50%)",
+                  background: "none", border: "none", cursor: "pointer", color: "var(--text-3)",
+                  padding: 4,
+                }}
+                aria-label={showSecret ? "Hide key" : "Show key"}
+              >
+                {showSecret ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+
+          {provider?.requires_base_url && (
+            <div>
+              <label style={{ display: "block", fontSize: 13, fontWeight: 600, marginBottom: 6 }}>
+                Base URL
+              </label>
+              <input
+                type="text"
+                value={baseUrl}
+                onChange={(e) => setBaseUrl(e.target.value)}
+                placeholder="https://your-host/v1"
+                style={inputStyle}
+              />
+            </div>
+          )}
+
+          <div>
+            <label style={{ display: "block", fontSize: 13, fontWeight: 600, marginBottom: 6 }}>
+              Default model
+            </label>
+            <input
+              type="text"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder={provider?.default_model ?? "model-name"}
+              style={{ ...inputStyle, fontFamily: "monospace" }}
+            />
+          </div>
+
+          {probeMsg && (
+            <div
+              style={{
+                padding: "10px 12px",
+                borderRadius: 8,
+                background: probeMsg.ok ? "var(--success-soft)" : "var(--danger-soft)",
+                color: probeMsg.ok ? "var(--success)" : "var(--danger)",
+                fontSize: 13,
+                lineHeight: 1.4,
+              }}
+            >
+              {probeMsg.text}
+            </div>
+          )}
+
+          {err && (
+            <div
+              style={{
+                padding: "10px 12px",
+                borderRadius: 8,
+                background: "var(--danger-soft)",
+                color: "var(--danger)",
+                fontSize: 13,
+                lineHeight: 1.4,
+                display: "flex",
+                gap: 8,
+                alignItems: "flex-start",
+              }}
+            >
+              <AlertCircle size={16} style={{ flexShrink: 0, marginTop: 1 }} />
+              <span>{err}</span>
+            </div>
+          )}
+
+          <div style={{ display: "flex", gap: 10, marginTop: 4 }}>
+            <button
+              type="button"
+              onClick={onProbe}
+              disabled={probing || (!secret.trim() && !provider?.allows_empty_key)}
+              style={{
+                background: "transparent",
+                color: "var(--text-1)",
+                border: "1px solid var(--border)",
+                borderRadius: 8,
+                padding: "10px 16px",
+                fontSize: 14,
+                fontWeight: 500,
+                cursor: probing ? "not-allowed" : "pointer",
+                opacity: probing ? 0.6 : 1,
+                display: "inline-flex", alignItems: "center", gap: 6,
+              }}
+            >
+              {probing
+                ? <><Loader2 size={14} style={{ animation: "spin 1s linear infinite" }} /> Testing…</>
+                : <><Wifi size={14} /> Test connection</>}
+            </button>
+            <button
+              type="submit"
+              disabled={saving || (!secret.trim() && !provider?.allows_empty_key)}
+              style={{
+                ...buttonPrimary,
+                cursor: saving ? "not-allowed" : "pointer",
+                opacity: saving ? 0.7 : 1,
+                display: "inline-flex", alignItems: "center", gap: 6,
+              }}
+            >
+              {saving
+                ? <><Loader2 size={14} style={{ animation: "spin 1s linear infinite" }} /> Saving…</>
+                : "Save and continue"}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <p style={{ textAlign: "center", color: "var(--text-3)", fontSize: 12, margin: 0 }}>
+        You can add more keys, change them, or remove them any time from the Settings tab.
+        Adding multiple keys enables automatic fall-over when one provider is rate limited.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/SettingsTab.tsx
+++ b/frontend/src/components/SettingsTab.tsx
@@ -273,12 +273,39 @@ export default function SettingsTab() {
           Settings
         </h2>
         <p style={{ color: "var(--text-2)", margin: "4px 0 0", fontSize: 13, lineHeight: 1.55 }}>
-          Optional: bring your own API keys for OpenAI-compatible providers. When configured,
-          you can pick "Use my API key" on the Upload tab and bills are extracted directly
-          via your account — no FreeLLMAPI router involved. Self-hosted endpoints (Ollama,
+          Manage the API keys used to parse uploaded bills. Add multiple keys to
+          enable automatic fall-over: when one provider is rate-limited, the
+          next healthy key in your list is used. Self-hosted endpoints (Ollama,
           custom gateways) are also supported via the Custom provider.
         </p>
       </div>
+
+      {keys.length >= 7 && (
+        <div
+          className="fade-in"
+          style={{
+            ...cardStyle,
+            marginBottom: 16,
+            borderLeft: "3px solid var(--warning)",
+            background: "var(--warning-soft)",
+            display: "flex",
+            gap: 10,
+            alignItems: "flex-start",
+          }}
+        >
+          <AlertCircle size={18} style={{ color: "var(--warning)", flexShrink: 0, marginTop: 1 }} />
+          <div style={{ fontSize: 13, lineHeight: 1.5 }}>
+            <div style={{ color: "var(--warning)", fontWeight: 600, marginBottom: 2 }}>
+              You have {keys.length} saved keys
+            </div>
+            <div style={{ color: "var(--text-2)" }}>
+              That's plenty of fall-over headroom. Consider deleting any that
+              you no longer use to keep the chain focused — extra keys don't
+              hurt accuracy, but they make the list harder to scan.
+            </div>
+          </div>
+        </div>
+      )}
 
       {!configured && (
         <div
@@ -395,6 +422,31 @@ export default function SettingsTab() {
                     {k.is_default && (
                       <span style={{ display: "flex", alignItems: "center", gap: 3, color: "var(--accent)", fontSize: 11, fontWeight: 600 }}>
                         <Star size={11} fill="currentColor" /> default
+                      </span>
+                    )}
+                    {/* Red badge when the auto-fallback chain has marked
+                        this key as exhausted (rate limited / out of credits
+                        / auth failed). The badge auto-clears after the
+                        cooldown window (1 hour) on the next list refresh
+                        — or sooner, on the next successful upload via
+                        this key. The full reason is shown on hover. */}
+                    {k.is_exhausted && (
+                      <span
+                        title={k.last_error ?? "rate limited"}
+                        style={{
+                          display: "flex", alignItems: "center", gap: 4,
+                          color: "var(--danger)", fontSize: 11, fontWeight: 600,
+                          padding: "2px 8px", borderRadius: 999,
+                          background: "var(--danger-soft)",
+                          border: "1px solid var(--danger)",
+                        }}
+                      >
+                        <AlertCircle size={11} />
+                        {k.last_error?.startsWith("out_of_credits")
+                          ? "out of credits"
+                          : k.last_error?.startsWith("auth_failed")
+                            ? "key rejected"
+                            : "rate limited"}
                       </span>
                     )}
                     {justAdded === k.id && (

--- a/frontend/src/components/UploadTab.tsx
+++ b/frontend/src/components/UploadTab.tsx
@@ -31,7 +31,6 @@ interface UploadTabProps {
 }
 
 type ItemStatus = "pending" | "uploading" | "success" | "replaced" | "error" | "low_quality" | "too_large";
-type ParserMode = "tesseract" | "freellmapi" | "byok";
 
 interface QueueItem {
   id: string;
@@ -40,11 +39,6 @@ interface QueueItem {
   errorMsg?: string;
   parsed?: Record<string, unknown>;
 }
-
-const FALLBACK_MODELS = [
-  { id: "auto", label: "Auto (FreeLLMAPI router)" },
-  { id: "__custom__", label: "Custom model ID…" },
-];
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -61,52 +55,23 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
   useEffect(() => {
     onRunningChange?.(running);
   }, [running, onRunningChange]);
-  const [parserMode, setParserMode] = useState<ParserMode>("freellmapi");
-  const [availableModels, setAvailableModels] = useState(FALLBACK_MODELS);
-  const [selectedModel, setSelectedModel] = useState(FALLBACK_MODELS[0].id);
-  const [customModel, setCustomModel] = useState("");
-  const [modelsLoading, setModelsLoading] = useState(true);
+
   const [expandedRow, setExpandedRow] = useState<string | null>(null);
+  // The Upload tab is now BYOK-only. The backend's auto-fallback chain
+  // (round-robin LRU across the user's saved keys, skipping any that
+  // were just rate-limited) decides which key to use, so the UI no
+  // longer offers a per-upload key picker. We still load the key list
+  // so we can warn the user when ALL of their keys are exhausted, and
+  // surface healthy/exhausted counts as ambient context.
   const [byokKeys, setByokKeys] = useState<ByokKey[]>([]);
-  const [byokKeyId, setByokKeyId] = useState<string>("");
-  const [byokModelOverride, setByokModelOverride] = useState<string>("");
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    api.getFreeLlmModels()
-      .then(res => {
-        if (cancelled) return;
-        const live = res.data.models || [];
-        const withCustom = [...live, { id: "__custom__", label: "Custom model ID…" }];
-        setAvailableModels(withCustom);
-        if (live.length > 0) setSelectedModel(live[0].id);
-      })
-      .catch(() => {
-        // Backend unreachable — keep fallback list.
-      })
-      .finally(() => {
-        if (!cancelled) setModelsLoading(false);
-      });
-    return () => { cancelled = true; };
-  }, []);
-
-  /** Refresh saved BYOK keys. Called on mount and whenever the user picks
-   * the BYOK parser mode (so adding/removing keys in Settings is reflected
-   * without remounting the always-mounted UploadTab). */
+  /** Refresh saved BYOK keys. Called on mount and whenever the Upload
+   *  tab becomes active so adding/removing keys in Settings is
+   *  reflected without remounting the always-mounted UploadTab. */
   const reloadByokKeys = useCallback(() => {
     api.listMyByokKeys()
-      .then(res => {
-        const keys = res.data ?? [];
-        setByokKeys(keys);
-        // Pick order: keep the user's current selection if still around,
-        // otherwise the global default key (any provider), otherwise the
-        // first listed key. The backend already orders defaults first.
-        setByokKeyId(prev => {
-          if (keys.find(k => k.id === prev)) return prev;
-          return keys.find(k => k.is_default)?.id ?? keys[0]?.id ?? "";
-        });
-      })
+      .then(res => setByokKeys(res.data ?? []))
       .catch(() => {
         // BYOK might be disabled on the server — keep the option hidden.
       });
@@ -116,10 +81,6 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
     reloadByokKeys();
   }, [reloadByokKeys]);
 
-  useEffect(() => {
-    if (parserMode === "byok") reloadByokKeys();
-  }, [parserMode, reloadByokKeys]);
-
   // Refetch when the Upload tab becomes active, so keys added in Settings
   // appear immediately on the user's next visit (UploadTab stays mounted
   // across tab switches to preserve in-flight queues).
@@ -127,44 +88,29 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
     if (isActive) reloadByokKeys();
   }, [isActive, reloadByokKeys]);
 
+  const healthyKeys = byokKeys.filter(k => !k.is_exhausted);
+  const exhaustedKeys = byokKeys.filter(k => k.is_exhausted);
+  const allKeysExhausted = byokKeys.length > 0 && healthyKeys.length === 0;
+
   const updateItem = useCallback((id: string, patch: Partial<QueueItem>) => {
     setQueue(q => q.map(it => (it.id === id ? { ...it, ...patch } : it)));
   }, []);
 
   const processQueue = useCallback(async (items: QueueItem[]) => {
     setRunning(true);
-    const effectiveModel =
-      parserMode === "freellmapi"
-        ? (selectedModel === "__custom__" ? customModel.trim() : selectedModel)
-        : parserMode === "byok"
-          ? byokModelOverride.trim() || undefined
-          : undefined;
-    const effectiveByokKeyId = parserMode === "byok" ? byokKeyId : undefined;
-
-    // Free-tier providers (Gemini, etc.) cap at ~10 requests/minute. Pace
-    // multi-file batches when going through FreeLLMAPI so we stay under
-    // their per-minute window. Local OCR and BYOK paid keys have no
-    // shared rate-limit concern, so they go back-to-back.
-    const pendingCount = items.filter(it => it.status === "pending").length;
-    const paceMs = parserMode === "freellmapi" && pendingCount > 1 ? 6500 : 0;
 
     let successCount = 0;
     let problemCount = 0;
-    let firstUpload = true;
+    let needsKeyRefresh = false;
     for (const item of items) {
       if (item.status !== "pending") continue;
-      if (!firstUpload && paceMs > 0) {
-        await new Promise(resolve => setTimeout(resolve, paceMs));
-      }
-      firstUpload = false;
       updateItem(item.id, { status: "uploading" });
       try {
-        const res = await api.uploadBill(
-          item.file,
-          parserMode,
-          effectiveModel || undefined,
-          effectiveByokKeyId || undefined,
-        );
+        // Always BYOK with no explicit key id — the backend rotates
+        // through the user's saved keys (LRU among healthy ones,
+        // skipping any that just got rate-limited). The user manages
+        // the key set in Settings; per-upload key picking is gone.
+        const res = await api.uploadBill(item.file, "byok");
         const parsed = res.data.parsed;
         const lowQuality = Boolean(parsed?._low_quality);
         if (lowQuality) {
@@ -185,19 +131,23 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
           if (typeof data.detail === "string") {
             msg = data.detail;
           } else if (data.detail && typeof data.detail === "object") {
-            const d = data.detail as { message?: string };
+            const d = data.detail as { message?: string; all_keys_exhausted?: boolean };
             if (typeof d.message === "string") msg = d.message;
+            if (d.all_keys_exhausted) needsKeyRefresh = true;
           }
         }
         updateItem(item.id, { status: "error", errorMsg: msg });
       }
     }
     setRunning(false);
+    // Refresh the keys list so the badge state reflects whatever the
+    // backend just marked exhausted.
+    if (needsKeyRefresh || problemCount > 0) reloadByokKeys();
     // Auto-navigate only if everything went smoothly (no errors, no low quality).
     if (successCount > 0 && problemCount === 0) {
       setTimeout(onSuccess, 2000);
     }
-  }, [parserMode, selectedModel, customModel, byokKeyId, byokModelOverride, updateItem, onSuccess]);
+  }, [updateItem, onSuccess, reloadByokKeys]);
 
   const addFiles = useCallback((files: File[]) => {
     if (files.length === 0) return;
@@ -253,16 +203,6 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
     padding: 24,
   };
 
-  const inputStyle: React.CSSProperties = {
-    width: "100%",
-    background: "var(--surface-2)",
-    border: "1px solid var(--border)",
-    borderRadius: 8,
-    color: "var(--text-1)",
-    padding: "8px 11px",
-    fontSize: 13,
-  };
-
   const allDone = queue.length > 0 && queue.every(it => it.status !== "pending" && it.status !== "uploading");
   const singleSuccess = queue.length === 1 && (queue[0].status === "success" || queue[0].status === "replaced" || queue[0].status === "low_quality");
   const detailItem = singleSuccess ? queue[0] : null;
@@ -278,131 +218,42 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
         Drop one or more files (up to {MAX_FILE_MB} MB each) to extract data.
       </p>
 
-      {/* Parser selector */}
-      <div style={{ ...cardStyle, marginBottom: 16, padding: 16 }}>
-        <div style={{ fontSize: 11, color: "var(--text-3)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 10, fontWeight: 600 }}>
-          Extraction method
-        </div>
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: byokKeys.length > 0
-              ? "repeat(auto-fit, minmax(150px, 1fr))"
-              : "repeat(auto-fit, minmax(180px, 1fr))",
-            gap: 8,
-            marginBottom: parserMode === "freellmapi" || parserMode === "byok" ? 12 : 0,
-          }}
-        >
-          {([
-            { id: "freellmapi", label: "🤖 FreeLLMAPI", desc: "Routed free LLM extraction" },
-            ...(byokKeys.length > 0
-              ? [{ id: "byok" as ParserMode, label: "🔑 My API key", desc: "Use one of your saved provider keys" }]
-              : []),
-            { id: "tesseract" as ParserMode, label: "🔍 Local OCR", desc: "Offline, no API key — Estonian utility bills" },
-          ] as { id: ParserMode; label: string; desc: string }[]).map(({ id, label, desc }) => (
-            <button
-              key={id}
-              onClick={() => setParserMode(id)}
-              disabled={running}
-              className="btn-press"
-              style={{
-                background: parserMode === id ? "var(--accent-soft)" : "var(--surface-2)",
-                border: `1.5px solid ${parserMode === id ? "var(--accent)" : "var(--border)"}`,
-                borderRadius: 10,
-                padding: "10px 12px",
-                cursor: running ? "not-allowed" : "pointer",
-                textAlign: "left",
-                opacity: running ? 0.6 : 1,
-              }}
-            >
-              <div style={{ color: parserMode === id ? "var(--accent)" : "var(--text-1)", fontSize: 13, fontWeight: 600 }}>{label}</div>
-              <div style={{ color: "var(--text-3)", fontSize: 11, marginTop: 2 }}>{desc}</div>
-            </button>
-          ))}
-        </div>
-
-        {parserMode === "freellmapi" && (
-          <div className="fade-in">
-            <label style={{ fontSize: 12, color: "var(--text-2)", display: "block", marginBottom: 4 }}>
-              Model {modelsLoading ? "(loading live list…)" : `(${availableModels.length - 1} available)`}
-            </label>
-            <select
-              value={selectedModel}
-              onChange={(e) => setSelectedModel(e.target.value)}
-              disabled={modelsLoading || running}
-              style={{
-                ...inputStyle,
-                cursor: modelsLoading || running ? "not-allowed" : "pointer",
-                opacity: modelsLoading || running ? 0.6 : 1,
-              }}
-            >
-              {availableModels.map(m => (
-                <option key={m.id} value={m.id}>{m.label}</option>
-              ))}
-            </select>
-            {selectedModel === "__custom__" && (
-              <input
-                type="text"
-                value={customModel}
-                onChange={(e) => setCustomModel(e.target.value)}
-                placeholder="e.g. gemini-2.5-flash"
-                disabled={running}
-                style={{
-                  ...inputStyle,
-                  marginTop: 6,
-                  fontFamily: "monospace",
-                }}
-              />
-            )}
-            <div style={{ fontSize: 11, color: "var(--text-3)", marginTop: 6 }}>
-              Manage provider keys and fallback order in the FreeLLMAPI dashboard at{" "}
-              <a href="http://localhost:3001" target="_blank" rel="noreferrer" style={{ color: "var(--accent)" }}>
-                localhost:3001
-              </a>
+      {/* Auto-routing status: replaces the old parser-mode picker.
+          Bills always go through the user's saved BYOK keys; the
+          backend chooses which one round-robin and falls over to the
+          next when one's rate-limited. */}
+      <div style={{ ...cardStyle, marginBottom: 16, padding: 14 }}>
+        {allKeysExhausted ? (
+          <div style={{ display: "flex", gap: 10, alignItems: "flex-start" }}>
+            <AlertCircle size={18} style={{ color: "var(--danger)", flexShrink: 0, marginTop: 2 }} />
+            <div style={{ fontSize: 13, lineHeight: 1.5 }}>
+              <div style={{ color: "var(--danger)", fontWeight: 600, marginBottom: 2 }}>
+                All saved API keys are currently rate-limited
+              </div>
+              <div style={{ color: "var(--text-2)" }}>
+                Wait a few minutes and try again, or add another provider in{" "}
+                <strong style={{ color: "var(--text-1)" }}>Settings</strong>.
+                Adding more keys lets the auto-fallback chain stay healthy.
+              </div>
             </div>
           </div>
-        )}
-
-        {parserMode === "byok" && (
-          <div className="fade-in" style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-            <label style={{ fontSize: 12, color: "var(--text-2)" }}>
-              Saved key
-              <select
-                value={byokKeyId}
-                onChange={(e) => setByokKeyId(e.target.value)}
-                disabled={running || byokKeys.length === 0}
-                style={{
-                  ...inputStyle,
-                  marginTop: 4,
-                  cursor: running ? "not-allowed" : "pointer",
-                }}
-              >
-                {byokKeys.map(k => (
-                  <option key={k.id} value={k.id}>
-                    {k.is_default ? "★ " : ""}{k.label} · {k.provider}
-                    {k.default_model ? ` · ${k.default_model}` : ""}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label style={{ fontSize: 12, color: "var(--text-2)" }}>
-              Model override <span style={{ color: "var(--text-3)" }}>(leave blank to use the key's default)</span>
-              <input
-                type="text"
-                value={byokModelOverride}
-                onChange={(e) => setByokModelOverride(e.target.value)}
-                placeholder={byokKeys.find(k => k.id === byokKeyId)?.default_model ?? ""}
-                disabled={running}
-                style={{
-                  ...inputStyle,
-                  marginTop: 4,
-                  fontFamily: "ui-monospace, SFMono-Regular, monospace",
-                }}
-              />
-            </label>
-            <div style={{ fontSize: 11, color: "var(--text-3)" }}>
-              Add or remove keys in the <strong style={{ color: "var(--text-1)" }}>Settings</strong> tab.
-              Bills uploaded with your key are billed to your provider account.
+        ) : (
+          <div style={{ display: "flex", gap: 10, alignItems: "flex-start" }}>
+            <Upload size={16} style={{ color: "var(--accent)", flexShrink: 0, marginTop: 3 }} />
+            <div style={{ fontSize: 13, lineHeight: 1.5 }}>
+              <div style={{ color: "var(--text-1)", fontWeight: 600, marginBottom: 2 }}>
+                Auto-routing across {byokKeys.length} saved key{byokKeys.length === 1 ? "" : "s"}
+                {exhaustedKeys.length > 0 && (
+                  <span style={{ color: "var(--text-3)", fontWeight: 400 }}>
+                    {" "}· {healthyKeys.length} healthy, {exhaustedKeys.length} rate-limited
+                  </span>
+                )}
+              </div>
+              <div style={{ color: "var(--text-3)", fontSize: 12 }}>
+                Manage keys in <strong style={{ color: "var(--text-1)" }}>Settings</strong>.
+                Each upload picks the least-recently-used healthy key, so adding more keys
+                spreads load and gives the chain somewhere to fall over.
+              </div>
             </div>
           </div>
         )}
@@ -498,7 +349,6 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
                 disabled={running}
                 expanded={expandedRow === item.id}
                 onToggle={(id) => setExpandedRow(prev => (prev === id ? null : id))}
-                parserMode={parserMode}
               />
             ))}
           </div>
@@ -536,24 +386,20 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
               </div>
             ) : null}
             <div style={{ color: "var(--text-1)", fontSize: 13, lineHeight: 1.5 }}>
-              {parserMode === "freellmapi" ? (
-                typeof parsed.error === "string" && /rate limit|exhausted/i.test(parsed.error) ? (
-                  <>
-                    Your provider hit its per-minute rate limit. Wait ~60 seconds
-                    and re-upload, or add another provider key to FreeLLMAPI so
-                    the router can fall over automatically.
-                  </>
-                ) : (
-                  <>
-                    Try a different model from the dropdown, or check that FreeLLMAPI
-                    has healthy provider keys configured.
-                  </>
-                )
+              {typeof parsed.error === "string" && /rate limit|exhausted|out of credits/i.test(parsed.error) ? (
+                <>
+                  All saved keys are temporarily rate-limited. Wait a few minutes
+                  and re-upload, or add another provider key in{" "}
+                  <strong style={{ color: "var(--accent)" }}>Settings</strong>{" "}
+                  so the auto-fallback chain has somewhere to go.
+                </>
               ) : (
                 <>
-                  The local OCR parser found very little data. Switch to{" "}
-                  <strong style={{ color: "var(--accent)" }}>AI (FreeLLMAPI)</strong> above and
-                  re-upload so FreeLLMAPI can structure the extracted text.
+                  Try uploading a clearer scan. If the issue is on the provider's
+                  end, check{" "}
+                  <strong style={{ color: "var(--accent)" }}>Settings</strong>{" "}
+                  for a per-key error badge — you may need to top up credits or
+                  rotate the key.
                 </>
               )}
             </div>
@@ -570,10 +416,10 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
           fontSize: 12,
         }}>
           <div style={{ color: "var(--accent)", fontWeight: 600, marginBottom: 4 }}>
-            FreeLLMAPI routed this request via <code>{String(parsed._routed_via)}</code>
+            Routed via <code>{String(parsed._routed_via)}</code>
           </div>
           <div style={{ color: "var(--text-3)" }}>
-            Requested model: <code>{String(parsed._model_used ?? "auto")}</code>
+            Model used: <code>{String(parsed._model_used ?? "auto")}</code>
           </div>
         </div>
       ) : null}
@@ -662,13 +508,14 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
       <div style={{ ...cardStyle, marginTop: 24 }}>
         <h3 style={{ color: "var(--text-1)", margin: "0 0 4px", fontSize: 14 }}>Supported Invoice Types</h3>
         <p style={{ color: "var(--text-3)", fontSize: 12, margin: "0 0 12px" }}>
-          Local OCR works best with standard-layout PDF invoices.
-          AI (FreeLLMAPI) uses local OCR first, then routes text extraction through your free LLM providers.
+          Local text extraction (OCR + native PDF) runs first; the result is then
+          structured by your saved AI provider. Any invoice format works — the
+          parser is provider-driven, not template-driven.
         </p>
 
         <div style={{ marginBottom: 10 }}>
           <div style={{ fontSize: 11, color: "var(--accent)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6, fontWeight: 600 }}>
-            Utility Bills (best local OCR accuracy)
+            Utility bills (highest extraction accuracy)
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
             {["Electricity", "Gas", "Water", "Heating", "Internet / Telecom", "Waste Collection", "Housing Association"].map(p => (
@@ -681,7 +528,7 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
 
         <div>
           <div style={{ fontSize: 11, color: "var(--text-2)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 6 }}>
-            Any invoice (AI / FreeLLMAPI)
+            Any invoice (AI-routed)
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
             {["Rent", "Subscriptions", "Services", "Repairs", "Insurance", "Any format or language"].map(p => (
@@ -703,10 +550,9 @@ interface QueueRowProps {
   disabled: boolean;
   expanded: boolean;
   onToggle: (id: string) => void;
-  parserMode: ParserMode;
 }
 
-function QueueRow({ item, index, onRemove, disabled, expanded, onToggle, parserMode }: QueueRowProps) {
+function QueueRow({ item, index, onRemove, disabled, expanded, onToggle }: QueueRowProps) {
   const { status, file, errorMsg, parsed } = item;
   const StatusIcon = (() => {
     switch (status) {
@@ -758,13 +604,10 @@ function QueueRow({ item, index, onRemove, disabled, expanded, onToggle, parserM
       return `Trim or compress the PDF below ${MAX_FILE_MB} MB and re-drop it. Most invoices fit easily — usually a scan resolution issue.`;
     }
     if (isRateLimit) {
-      return "Your provider hit its per-minute rate limit. Wait ~60 seconds and re-upload, or add another provider key to FreeLLMAPI so the router can fall over.";
+      return "All saved API keys are temporarily rate-limited. Wait a few minutes and re-upload, or add another provider in Settings so the auto-fallback chain has somewhere to go.";
     }
-    if (status === "low_quality" && parserMode !== "freellmapi") {
-      return "The local OCR parser found very little data. Switch to AI (FreeLLMAPI) above and re-upload so a free LLM can structure the extracted text.";
-    }
-    if (status === "low_quality" && parserMode === "freellmapi") {
-      return "The model returned a response but with too few useful fields. Try a different model from the dropdown, or re-upload with a clearer scan.";
+    if (status === "low_quality") {
+      return "The model returned a response but with too few useful fields. Try a clearer scan, or pick a stronger model on one of your saved keys (Settings → Edit → Default model).";
     }
     return "Try uploading the file again. If this keeps happening, check the browser console for the underlying network error.";
   })();


### PR DESCRIPTION
Reworks the upload UX so every user funnels through their own AI provider key, with the backend rotating across multiple keys automatically when one is rate-limited or out of credits. Implements the user's requested onboarding flow + auto-fallback semantics.

## Frontend

- **OnboardingScreen** (new): freshly-signed-in users with zero saved BYOK keys are gated behind a dedicated "add your first key" screen before they can reach Upload / Bills / Analytics. Prioritises the recommended free providers (Groq, Google, Cerebras, OpenRouter) but lets the user pick anything. Adding one key dismisses the gate.

- **Upload tab simplified**: the parser-mode picker (Local OCR / FreeLLMAPI / My API key) is gone. Uploads always run through the user's saved BYOK keys via the auto-fallback chain — no per-upload key picking, no FreeLLMAPI model dropdown, no model override field. In its place: a single status banner showing "Auto-routing across N saved keys (X healthy, Y rate-limited)" with a hard banner when every key is exhausted. FreeLLMAPI and Tesseract paths are **kept on the backend** (soft deprecation) so existing deployments still work via env var.

- **Settings tab**: red "rate limited" / "out of credits" / "key rejected" badge next to any key the chain has marked exhausted inside the 1-hour cooldown window, with the full upstream message on hover. Soft warning banner at 7+ keys (no hard cap).

## Backend

### Schema migration (idempotent on SQLite + Postgres)

Three new columns on \`user_api_keys\`:
- \`last_used_at\` — drives LRU round-robin selection
- \`last_error\` — typed error string set when the chain marks the key exhausted
- \`last_error_at\` — when that happened; the chain considers the key healthy again after 1 hour

### \`KeyExhaustedError\` (new)

Raised in place of \`RuntimeError\` when the upstream response matches a key-specific failure (HTTP 429, 402, 401/403, OpenAI's \`insufficient_quota\` / \`invalid_api_key\` typed errors). The upload endpoint catches this specifically so the chain knows to fall over to the next key. Generic \`RuntimeError\`s still bubble up — trying another key won't help with those.

### Auto-fallback chain (\`_parse_with_byok_chain\`)

When the upload comes in without an explicit \`byok_key_id\`:
1. List the user's keys ordered by \`last_used_at ASC NULLS FIRST\` (LRU round-robin)
2. Healthy keys (no recent error) before exhausted ones
3. For each: success clears the exhaustion flag and bumps \`last_used_at\`; \`KeyExhaustedError\` marks the key and continues to the next
4. All keys exhausted → HTTP 422 with \`all_keys_exhausted: True\` + per-key failure list
5. Empty key list → HTTP 422 with \`no_keys: True\`

### Pinned-key path preserved

Passing an explicit \`byok_key_id\` bypasses the chain. The exhaustion flag is still recorded so Settings badges update, but no other key is tried — explicit pin = explicit single-shot.

### Outer try/except in upload_bill

Now re-raises HTTPException rather than swallowing it into the generic "low_quality" path. The fallback chain raises structured 422s (\`no_keys\` / \`all_keys_exhausted\` / \`failures[]\`) that the frontend pattern-matches on.

## Test plan

10 new tests in \`backend/test_byok_fallback.py\`:

- [x] \`KeyExhaustedError\` carries machine-readable \`kind\`
- [x] \`_classify_key_exhaustion\` recognises typed error envelopes (\`insufficient_quota\`, \`invalid_api_key\`, plain 429, generic 500)
- [x] LRU round-robin: NULL \`last_used_at\` first, then by \`created_at\`
- [x] Rate-limited first key falls over to second key (user sees clean 200)
- [x] Out-of-credits failure recorded with correct \`kind\`
- [x] All-keys-exhausted ⇒ 422 + structured failures list
- [x] No keys at all ⇒ 422 with \`no_keys: True\`
- [x] Cooldown window (1h): exhausted key skipped within window, retried after backdating
- [x] Per-user isolation: Bob's exhausted state never affects Alice
- [x] Pinned \`byok_key_id\` does NOT fall over

Backend suite: **107 passed** (97 pre-existing + 10 new). Ruff clean. Frontend tsc + eslint + vite build clean.

## Migration notes

- Existing users with at least one saved BYOK key see no difference except the new badges + simpler Upload tab
- Existing users with **zero** keys will hit the OnboardingScreen on next sign-in — they need to add a key to keep using the app
- Operators who want to keep Tesseract or FreeLLMAPI as a deployment-default backend can set \`PARSER_BACKEND=tesseract\` or \`PARSER_BACKEND=freellmapi\`; the new UI always sends \`parser=byok\` so this only affects callers that omit the form field

Made with [Cursor](https://cursor.com)