### PR TITLE
fix(ui): React error #31 on multi-tariff bills with object-typed meter readings

### DIFF
--- a/backend/test_audit_regressions.py
+++ b/backend/test_audit_regressions.py
@@ -802,6 +802,100 @@ def test_glossary_fallback_runs_when_ai_did_not_translate():
     assert items[1]["description_en"]
 
 
+# ─── Multi-tariff meter readings: enrich_parsed normalises dict-typed scalars ─
+
+def test_enrich_parsed_flattens_dict_meter_readings_to_string():
+    """Multi-tariff Estonian bills (separate day/night electricity, hot/cold
+    water on the same invoice) tempt LLMs into returning a dict like
+    `{"electricity_day": 9494, "cold_water": 443.5}` for fields the
+    schema documents as scalar. The frontend then crashes with React
+    error #31 ('Objects are not valid as a React child') because the
+    grid renderer feeds the dict straight into JSX. enrich_parsed
+    must normalise these to a renderable string."""
+    from translation import enrich_parsed
+
+    parsed = {
+        "provider": "Eesti Energia",
+        "amount_eur": 75.0,
+        "meter_reading_start": {
+            "electricity_day": 9494,
+            "electricity_night": 7283,
+            "cold_water": 443.5,
+            "hot_water": 220.1,
+        },
+        "meter_reading_end": {
+            "electricity_day": 9559,
+            "electricity_night": 7340,
+            "cold_water": 446.2,
+            "hot_water": 222.8,
+        },
+        "line_items": [],
+    }
+    out = enrich_parsed(parsed)
+    assert isinstance(out["meter_reading_start"], str), (
+        "Dict-typed meter_reading_start must be flattened to a string "
+        "so the frontend grid renderer doesn't crash"
+    )
+    # Format is "key: value, key: value …" — preserves all the
+    # information without losing any tariff.
+    s = out["meter_reading_start"]
+    assert "electricity_day: 9494" in s
+    assert "cold_water: 443.5" in s
+    # Symmetric handling for meter_reading_end.
+    assert isinstance(out["meter_reading_end"], str)
+    assert "electricity_day: 9559" in out["meter_reading_end"]
+
+
+def test_enrich_parsed_leaves_already_scalar_meter_readings_alone():
+    """When the AI follows the schema and returns a number, the field
+    stays a number — the frontend has number-friendly formatting
+    (€-prefix, .toFixed) that we shouldn't break for the common case."""
+    from translation import enrich_parsed
+
+    parsed = {
+        "provider": "Eesti Energia",
+        "amount_eur": 50.0,
+        "meter_reading_start": 9494,
+        "meter_reading_end": 9559,
+        "line_items": [],
+    }
+    out = enrich_parsed(parsed)
+    assert out["meter_reading_start"] == 9494
+    assert out["meter_reading_end"] == 9559
+
+
+def test_enrich_parsed_collapses_empty_dict_to_none():
+    """An empty dict for a documented-scalar field is just noise —
+    collapse it to None so the frontend's truthy-check skips the row
+    entirely instead of rendering an empty label."""
+    from translation import enrich_parsed
+
+    parsed = {
+        "provider": "Eesti Energia",
+        "amount_eur": 50.0,
+        "meter_reading_start": {},
+        "line_items": [],
+    }
+    out = enrich_parsed(parsed)
+    assert out["meter_reading_start"] is None
+
+
+def test_enrich_parsed_handles_list_typed_scalars_too():
+    """Less common but seen in the wild: AI returns a list of values
+    instead of a dict (e.g. [9494, 7283]). Same fix applies — flatten
+    to a renderable string so React doesn't crash."""
+    from translation import enrich_parsed
+
+    parsed = {
+        "provider": "Eesti Energia",
+        "amount_eur": 50.0,
+        "meter_reading_start": [9494, 7283],
+        "line_items": [],
+    }
+    out = enrich_parsed(parsed)
+    assert out["meter_reading_start"] == "9494, 7283"
+
+
 def test_ai_english_equal_to_estonian_falls_back_to_glossary():
     """Some AI parsers, when uncertain, just echo the source text in
     both fields. Treat that as 'no translation provided' and fall back

--- a/backend/translation.py
+++ b/backend/translation.py
@@ -613,11 +613,66 @@ def generate_summary(parsed: dict) -> str:
     return " ".join(parts)
 
 
+def _normalize_scalar(value):
+    """Coerce a documented-scalar field that the AI returned as a dict
+    or a list into a renderable string. Multi-tariff bills tempt LLMs
+    into returning structured meter readings like
+    ``{"electricity_day": 9494, "electricity_night": 7283}`` for a
+    field the schema documents as a single number — and the frontend
+    crashes (React error #31) when fed that object directly. Flatten
+    to ``"electricity_day: 9494, electricity_night: 7283"`` so the
+    information survives without breaking the UI.
+
+    Empty containers collapse to ``None`` so the frontend's
+    truthy-check still skips the row instead of rendering an empty
+    label.
+    """
+    if isinstance(value, dict):
+        parts = [f"{k}: {v}" for k, v in value.items() if v is not None]
+        return ", ".join(parts) if parts else None
+    if isinstance(value, list):
+        parts = [str(x) for x in value if x is not None]
+        return ", ".join(parts) if parts else None
+    return value
+
+
+# Fields documented in the extraction prompt as scalar (string or
+# numeric). Anything an LLM returns that's a dict / list on these
+# names is by definition a schema violation we want to repair.
+_SCALAR_FIELDS = (
+    "provider",
+    "utility_type",
+    "amount_eur",
+    "consumption_kwh",
+    "consumption_m3",
+    "bill_date",
+    "period_start",
+    "period_end",
+    "period",
+    "account_number",
+    "address",
+    "vat_amount",
+    "amount_without_vat",
+    "meter_reading_start",
+    "meter_reading_end",
+    "due_date",
+    "confidence",
+)
+
+
 def enrich_parsed(parsed: dict) -> dict:
     """
     Take the raw dict from Claude (extraction only) and add all
     translation fields without any API call.
     """
+    # Defend against AI parsers that return a dict or list for fields
+    # the schema documents as scalar — see `_normalize_scalar`. We
+    # mutate a copy so the caller's dict isn't surprised by the
+    # rewrite.
+    parsed = {
+        k: _normalize_scalar(v) if k in _SCALAR_FIELDS else v
+        for k, v in parsed.items()
+    }
     # Translate line items
     raw_items = parsed.get("line_items") or []
     translated_items = translate_line_items(raw_items)

--- a/frontend/src/components/BillsTab.tsx
+++ b/frontend/src/components/BillsTab.tsx
@@ -11,6 +11,37 @@ const UTILITY_ICONS: Record<string, string> = {
   heating: "♨️", internet: "🌐", waste: "🗑️", other: "📄",
 };
 
+/**
+ * Render any extracted-bill field as a string we can safely drop into
+ * JSX. The backend now normalises documented-scalar fields in
+ * `enrich_parsed`, but old bills already stored before that landed
+ * still have raw dicts / arrays in their `raw_json` (e.g. multi-tariff
+ * bills where the AI returned `{electricity_day: 9494,
+ * electricity_night: 7283}` for `meter_reading_start`). Without this
+ * coercion React 19 throws "Objects are not valid as a React child"
+ * (error #31) and the whole Bills tab crashes when the user expands
+ * one of those rows.
+ *
+ * Returns `null` for empty / missing values so the calling renderer
+ * can skip the row entirely instead of showing an empty label.
+ */
+function renderScalar(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "string") return value || null;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) {
+    const parts = value.filter(v => v != null).map(v => renderScalar(v) ?? "");
+    return parts.length ? parts.join(", ") : null;
+  }
+  if (typeof value === "object") {
+    const parts = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v != null)
+      .map(([k, v]) => `${k}: ${renderScalar(v) ?? ""}`);
+    return parts.length ? parts.join(", ") : null;
+  }
+  return String(value);
+}
+
 const TYPE_COLORS: Record<string, string> = {
   electricity: "#f59e0b", gas: "#f97316", water: "#3b82f6",
   heating: "#ef4444", internet: "#8b5cf6", waste: "#6b7280", other: "#9ca3af",
@@ -497,24 +528,28 @@ export default function BillsTab({ onDataChange }: BillsTabProps = {}) {
                   )}
 
                   <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))", gap: "12px 24px" }}>
-                    {[
+                    {([
                       ["Account #", bill.account_number],
                       ["Address", bill.address],
                       ["Filename", bill.filename],
-                      ["Uploaded", fmtLocal(bill.upload_date)?.absolute],
+                      ["Uploaded", fmtLocal(bill.upload_date)?.absolute ?? null],
                       ["Due Date", raw.due_date],
                       ["Period (EN)", raw.period_en ?? raw.period],
-                      ["VAT", raw.vat_amount != null ? `€${raw.vat_amount}` : null],
-                      ["Without VAT", raw.amount_without_vat != null ? `€${raw.amount_without_vat}` : null],
+                      ["VAT", raw.vat_amount != null ? `€${renderScalar(raw.vat_amount)}` : null],
+                      ["Without VAT", raw.amount_without_vat != null ? `€${renderScalar(raw.amount_without_vat)}` : null],
                       ["Meter Start", raw.meter_reading_start],
                       ["Meter End", raw.meter_reading_end],
                       ["Confidence", raw.confidence],
-                    ].map(([label, val]) => val ? (
-                      <div key={label as string}>
-                        <div style={{ fontSize: 11, color: "var(--text-3)", textTransform: "uppercase", letterSpacing: "0.05em" }}>{label}</div>
-                        <div style={{ fontSize: 13, color: "var(--text-1)", marginTop: 2, wordBreak: "break-all" }}>{val as string}</div>
-                      </div>
-                    ) : null)}
+                    ] as Array<[string, unknown]>).map(([label, val]) => {
+                      const text = renderScalar(val);
+                      if (!text) return null;
+                      return (
+                        <div key={label}>
+                          <div style={{ fontSize: 11, color: "var(--text-3)", textTransform: "uppercase", letterSpacing: "0.05em" }}>{label}</div>
+                          <div style={{ fontSize: 13, color: "var(--text-1)", marginTop: 2, wordBreak: "break-all" }}>{text}</div>
+                        </div>
+                      );
+                    })}
                   </div>
 
                   {Array.isArray(raw.line_items) && raw.line_items.length > 0 && (
@@ -534,10 +569,10 @@ export default function BillsTab({ onDataChange }: BillsTabProps = {}) {
                         <tbody>
                           {(raw.line_items as Array<Record<string, unknown>>).map((li, i) => (
                             <tr key={i} style={{ borderBottom: "1px solid var(--divider)" }}>
-                              <td style={{ padding: "6px 8px 6px 0", color: "var(--text-2)" }}>{String(li.description_et ?? "—")}</td>
-                              <td style={{ padding: "6px 0", color: "var(--text-1)" }}>{String(li.description_en ?? "—")}</td>
+                              <td style={{ padding: "6px 8px 6px 0", color: "var(--text-2)" }}>{renderScalar(li.description_et) ?? "—"}</td>
+                              <td style={{ padding: "6px 0", color: "var(--text-1)" }}>{renderScalar(li.description_en) ?? "—"}</td>
                               <td style={{ padding: "6px 0", textAlign: "right", color: "var(--success)", fontVariantNumeric: "tabular-nums" }}>
-                                {li.amount_eur != null ? `€${(li.amount_eur as number).toFixed(2)}` : "—"}
+                                {typeof li.amount_eur === "number" ? `€${li.amount_eur.toFixed(2)}` : (renderScalar(li.amount_eur) ?? "—")}
                               </td>
                             </tr>
                           ))}

--- a/frontend/src/components/UploadTab.tsx
+++ b/frontend/src/components/UploadTab.tsx
@@ -16,6 +16,33 @@ const UTILITY_ICONS: Record<string, string> = {
   other: "📄",
 };
 
+/**
+ * Coerce any extracted-bill field to a renderable string. Multi-tariff
+ * bills sometimes return structured objects (e.g.
+ * `{electricity_day: 9494, electricity_night: 7283}`) for fields the
+ * schema documents as scalar; React 19 throws "Objects are not valid
+ * as a React child" (error #31) when those slip into JSX. The backend
+ * now normalises these in `enrich_parsed`, but stored bills uploaded
+ * before that fix still have raw dicts in `raw_json`, so we defend
+ * here too. Returns null for empty values so the row is skipped.
+ */
+function renderScalar(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "string") return value || null;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) {
+    const parts = value.filter(v => v != null).map(v => renderScalar(v) ?? "");
+    return parts.length ? parts.join(", ") : null;
+  }
+  if (typeof value === "object") {
+    const parts = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v != null)
+      .map(([k, v]) => `${k}: ${renderScalar(v) ?? ""}`);
+    return parts.length ? parts.join(", ") : null;
+  }
+  return String(value);
+}
+
 const MAX_FILE_BYTES = 25 * 1024 * 1024; // 25 MB — must match backend MAX_UPLOAD_BYTES
 const MAX_FILE_MB = MAX_FILE_BYTES / (1024 * 1024);
 
@@ -431,23 +458,25 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
               {UTILITY_ICONS[parsed.utility_type as string] || "📄"} Extracted Details
             </h3>
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px 24px" }}>
-              {[
+              {([
                 ["Provider", parsed.provider],
                 ["Type", parsed.utility_type],
-                ["Amount", parsed.amount_eur != null ? `€${(parsed.amount_eur as number).toFixed(2)}` : null],
+                ["Amount", typeof parsed.amount_eur === "number" ? `€${parsed.amount_eur.toFixed(2)}` : parsed.amount_eur],
                 ["Bill Date", parsed.bill_date],
-                ["Period", parsed.period_en ?? (parsed.period_start && parsed.period_end ? `${parsed.period_start} → ${parsed.period_end}` : parsed.period)],
-                ["Consumption", parsed.consumption_kwh != null ? `${parsed.consumption_kwh} kWh` : parsed.consumption_m3 != null ? `${parsed.consumption_m3} m³` : null],
+                ["Period", parsed.period_en ?? (parsed.period_start && parsed.period_end ? `${renderScalar(parsed.period_start) ?? ""} → ${renderScalar(parsed.period_end) ?? ""}` : parsed.period)],
+                ["Consumption", parsed.consumption_kwh != null ? `${renderScalar(parsed.consumption_kwh)} kWh` : parsed.consumption_m3 != null ? `${renderScalar(parsed.consumption_m3)} m³` : null],
                 ["Account", parsed.account_number],
                 ["Confidence", parsed.confidence],
-              ].map(([label, value]) =>
-                value ? (
-                  <div key={String(label)}>
-                    <div style={{ fontSize: 11, color: "var(--text-3)", textTransform: "uppercase", letterSpacing: "0.05em" }}>{String(label)}</div>
-                    <div style={{ fontSize: 14, color: "var(--text-1)", marginTop: 2 }}>{String(value)}</div>
+              ] as Array<[string, unknown]>).map(([label, value]) => {
+                const text = renderScalar(value);
+                if (!text) return null;
+                return (
+                  <div key={label}>
+                    <div style={{ fontSize: 11, color: "var(--text-3)", textTransform: "uppercase", letterSpacing: "0.05em" }}>{label}</div>
+                    <div style={{ fontSize: 14, color: "var(--text-1)", marginTop: 2 }}>{text}</div>
                   </div>
-                ) : null
-              )}
+                );
+              })}
             </div>
           </div>
 
@@ -476,10 +505,10 @@ export default function UploadTab({ onSuccess, onRunningChange, isActive }: Uplo
                 <tbody>
                   {(parsed.line_items as Array<Record<string, unknown>>).map((li, i) => (
                     <tr key={i} style={{ borderBottom: "1px solid var(--divider)" }}>
-                      <td style={{ padding: "8px 8px 8px 0", color: "var(--text-2)" }}>{String(li.description_et ?? "—")}</td>
-                      <td style={{ padding: "8px 0", color: "var(--text-1)" }}>{String(li.description_en ?? "—")}</td>
+                      <td style={{ padding: "8px 8px 8px 0", color: "var(--text-2)" }}>{renderScalar(li.description_et) ?? "—"}</td>
+                      <td style={{ padding: "8px 0", color: "var(--text-1)" }}>{renderScalar(li.description_en) ?? "—"}</td>
                       <td style={{ padding: "8px 0", textAlign: "right", color: "var(--success)", fontVariantNumeric: "tabular-nums" }}>
-                        {li.amount_eur != null ? `€${(li.amount_eur as number).toFixed(2)}` : "—"}
+                        {typeof li.amount_eur === "number" ? `€${li.amount_eur.toFixed(2)}` : (renderScalar(li.amount_eur) ?? "—")}
                       </td>
                     </tr>
                   ))}


### PR DESCRIPTION
**Reported error**: \`Minified React error #31; ... object with keys {electricity_day, electricity_night, cold_water, hot_water}\`

## Root cause

The extraction prompt in \`backend/parser_openai_compat.py\` documents \`meter_reading_start\` / \`meter_reading_end\` as a single number. But multi-tariff Estonian bills (separate day/night electricity + hot/cold water on one invoice) tempt LLMs into returning:

\`\`\`json
{
  "electricity_day": 9494,
  "electricity_night": 7283,
  "cold_water": 443.5,
  "hot_water": 220.1
}
\`\`\`

The frontend's BillsTab grid renderer then does \`{val as string}\` — a TypeScript-only cast that doesn't actually coerce at runtime — and React 19 throws when the dict reaches JSX, crashing the Bills tab the moment the user expands one of these rows.

## Fix (two layers, defence in depth)

### 1. Backend normalisation in \`enrich_parsed\`

New \`_normalize_scalar\` helper flattens any dict/list value on documented-scalar fields (\`meter_reading_*\`, \`consumption_*\`, \`amount_*\`, \`vat_amount\`, \`period_*\`, …) into a \`"k1: v1, k2: v2"\` string, preserving every tariff. Empty containers collapse to \`None\` so the frontend's truthy-check still skips the row instead of rendering an empty label. Already-scalar values pass through unchanged so the common-case formatting (€-prefix, .toFixed) still works.

### 2. Frontend defensive \`renderScalar\` in BillsTab + UploadTab

Replaces the unsafe \`{val as string}\` and \`String(val)\` patterns. Recursively handles dict / array / scalar values, returns null for empty values so the row is skipped, never feeds an object directly to React. Also tightened the line-items table renderers that used \`(li.amount_eur as number).toFixed(2)\` — a TypeScript lie that would throw \`TypeError\` at runtime if the AI returned a dict for the amount.

**Both layers are needed**: the backend fix prevents new crashes for fresh uploads, but stored bills saved before this lands still have raw dicts in \`raw_json\`, so the Bills tab needs to render them safely too.

## Test plan

4 new tests in \`backend/test_audit_regressions.py\`:

- [x] \`enrich_parsed\` flattens dict-typed meter readings to a renderable string (covers the exact user-reported case)
- [x] Already-scalar meter readings pass through untouched (don't break common-case formatting)
- [x] Empty dict collapses to \`None\` (so the frontend skips the row)
- [x] List-typed scalars also get flattened

Each new "must-not-crash" test verified to fail on master (\`assert [9494, 7283] == '9494, 7283'\` etc.) and pass with the fix.

Backend suite: **111 passed** (107 + 4 new). Ruff clean. Frontend tsc + eslint + vite build clean.

## After merge

Once Render redeploys, the user can re-open the offending bill — it'll now display:

\`\`\`
Meter Start: electricity_day: 9494, electricity_night: 7283, cold_water: 443.5, hot_water: 220.1
Meter End:   electricity_day: 9559, electricity_night: 7340, cold_water: 446.2, hot_water: 222.8
\`\`\`

…instead of crashing the tab. New uploads of multi-tariff bills will be normalised at extraction time so the data is consistent going forward.

Made with [Cursor](https://cursor.com)